### PR TITLE
Allow swizzleRanks on empty tensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ debug.py
 *~
 \#*\#
 
+# Vim files
+*.swp
+
 #pycharm
 **/.idea/
 venv/

--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -138,7 +138,7 @@ class Fiber:
 
     """
 
-   
+
     def __init__(self,
                  coords=None,
                  payloads=None,
@@ -477,7 +477,7 @@ class Fiber:
         `Fiber.payloads` class instance variable directly.
 
         """
-        
+
         return self.payloads
 
 
@@ -1023,7 +1023,7 @@ class Fiber:
 
         TBD
         ----
-        
+
         Add support for **shortcuts**.
 
         """
@@ -1272,7 +1272,7 @@ class Fiber:
         next_default: a payload (boxed or unboxed)
             If `default` is a Fiber then a default payload for that fiber
 
-        addtorank: Boolean 
+        addtorank: Boolean
             If the newly created value is a fiber, then should that fiber
             be added to the its owning rank (owner.next_rank)
 
@@ -1834,7 +1834,7 @@ class Fiber:
         Nothing
 
         """
-        
+
         self.coords.clear()
         self.payloads.clear()
 
@@ -2493,7 +2493,7 @@ class Fiber:
 
 
     def splitUniform(self, step, partitions=1, relativeCoords=False, depth=0, rankid=None):
-        """Split a fiber uniformly in coordinate space 
+        """Split a fiber uniformly in coordinate space
 
         Parameters
         ----------
@@ -2559,7 +2559,7 @@ class Fiber:
 
 
     def splitNonUniform(self, splits, partitions=1, relativeCoords=False, depth=0, rankid=None):
-        """Split a fiber non-uniformly in coordinate space 
+        """Split a fiber non-uniformly in coordinate space
 
         Parameters
         ----------
@@ -3618,6 +3618,9 @@ class Fiber:
         # Flatten the (highest) two ranks
         #
         flattened = self.flattenRanks(style="pair")
+
+        # Make sure that the flattened fiber has at least one coordinate
+        assert(len(flattened.coords) > 0)
 
         # Make sure the coord is a >=2-element tuple
         assert(len(flattened.coords[0]) >= 2)

--- a/fibertree/core/tensor.py
+++ b/fibertree/core/tensor.py
@@ -1279,9 +1279,14 @@ class Tensor:
         #
         shape = None
 
-        root = self._modifyRoot(Fiber.swapRanks,
-                                Fiber.swapRanksBelow,
-                                depth=depth)
+        # TODO
+        if not all(fiber.isEmpty() for fiber in self.ranks[depth].fibers):
+            root = self._modifyRoot(Fiber.swapRanks,
+                                    Fiber.swapRanksBelow,
+                                    depth=depth)
+        else:
+            root = copy.deepcopy(self.getRoot())
+
         #
         # Create Tensor from rank_ids and root fiber
         #

--- a/fibertree/core/tensor.py
+++ b/fibertree/core/tensor.py
@@ -1279,7 +1279,7 @@ class Tensor:
         #
         shape = None
 
-        # TODO
+        # Only call Fiber.swapRanks if there are actually payloads to swap
         if not all(fiber.isEmpty() for fiber in self.ranks[depth].fibers):
             root = self._modifyRoot(Fiber.swapRanks,
                                     Fiber.swapRanksBelow,

--- a/test/test_fiber_mutator.py
+++ b/test/test_fiber_mutator.py
@@ -9,6 +9,13 @@ from fibertree import TensorImage
 
 class TestFiberMutator(unittest.TestCase):
 
+    def test_swapRanks_empty(self):
+        """Test that swapRanks raises an error if the fiber is empty"""
+        z_m = Fiber()
+
+        with self.assertRaises(AssertionError):
+            z_m.swapRanks()
+
     def test_split_uniform_below(self):
         """Test splitUniformBelow"""
 

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -26,7 +26,7 @@ class TestTensorTransform(unittest.TestCase):
                 self.assertEqual(a_out.getShape(), [26, 41, 42, 10])
 
 
-        
+
     def test_splitUniform_1(self):
         """ Test splitUniform - depth=1 """
 
@@ -255,7 +255,7 @@ class TestTensorTransform(unittest.TestCase):
     def test_swizzleRanks(self):
         """ Test swizzleRanks """
 
-        a_MK = Tensor.fromUncompressed(["M", "K"], 
+        a_MK = Tensor.fromUncompressed(["M", "K"],
                                [[0, 0, 4, 0, 0, 5],
                                 [3, 2, 0, 3, 0, 2],
                                 [0, 2, 0, 0, 1, 2],
@@ -290,6 +290,14 @@ class TestTensorTransform(unittest.TestCase):
 
         a_MMKK_2 = a_MKMK.swizzleRanks(["M.1", "M.0", "K.1", "K.0"])
         self.assertEqual(a_MMKK_2, a_MMKK)
+
+    def test_swizzleRanks_empty(self):
+        """ Test swizzleRanks() on an empty tensor """
+        Z_MNOP = Tensor(rank_ids=["M", "N", "O", "P"])
+        Z_PNMO = Z_MNOP.swizzleRanks(rank_ids=["P", "N", "M", "O"])
+
+        self.assertEqual(Z_MNOP.getRankIds(), ["M", "N", "O", "P"])
+        self.assertEqual(Z_PNMO.getRankIds(), ["P", "N", "M", "O"])
 
 
     def test_flattenRanks_0(self):
@@ -326,7 +334,7 @@ class TestTensorTransform(unittest.TestCase):
 
         f01 = t0.flattenRanks(depth=0, levels=1)
         u01 = f01.unflattenRanks(depth=0, levels=1)
-        
+
         self.assertEqual(u01, t0)
 
     def test_flattenRanks_f02(self):
@@ -360,7 +368,7 @@ class TestTensorTransform(unittest.TestCase):
         t0 = Tensor.fromYAMLfile("./data/tensor_3d-0.yaml")
         t1 = Tensor.fromYAMLfile("./data/tensor_3d-1.yaml")
 
-        t2 = Tensor.fromFiber(["A", "B", "C", "D"], 
+        t2 = Tensor.fromFiber(["A", "B", "C", "D"],
                               Fiber([1, 4], [t0.getRoot(), t1.getRoot()]),
                               name="t2")
 


### PR DESCRIPTION
This PR allows empty tensors to be swizzled by only calling `Fiber.swapRanks` if the tensor is not empty. Also, swapping ranks of an empty fiber is explicitly prohibited with an additional assert.

Note: I have my editor configured to automatically remove trailing whitespace, so those changes appear in the diff. I can revert those to have a cleaner diff if that is desirable