### PR TITLE
Propagate coordinate styles across multiple levels of flattening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ debug.py
 *~
 \#*\#
 
+# Vim files
+*.swp
+
 #pycharm
 **/.idea/
 venv/

--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -138,7 +138,7 @@ class Fiber:
 
     """
 
-   
+
     def __init__(self,
                  coords=None,
                  payloads=None,
@@ -477,7 +477,7 @@ class Fiber:
         `Fiber.payloads` class instance variable directly.
 
         """
-        
+
         return self.payloads
 
 
@@ -1023,7 +1023,7 @@ class Fiber:
 
         TBD
         ----
-        
+
         Add support for **shortcuts**.
 
         """
@@ -1272,7 +1272,7 @@ class Fiber:
         next_default: a payload (boxed or unboxed)
             If `default` is a Fiber then a default payload for that fiber
 
-        addtorank: Boolean 
+        addtorank: Boolean
             If the newly created value is a fiber, then should that fiber
             be added to the its owning rank (owner.next_rank)
 
@@ -1834,7 +1834,7 @@ class Fiber:
         Nothing
 
         """
-        
+
         self.coords.clear()
         self.payloads.clear()
 
@@ -2493,7 +2493,7 @@ class Fiber:
 
 
     def splitUniform(self, step, partitions=1, relativeCoords=False, depth=0, rankid=None):
-        """Split a fiber uniformly in coordinate space 
+        """Split a fiber uniformly in coordinate space
 
         Parameters
         ----------
@@ -2559,7 +2559,7 @@ class Fiber:
 
 
     def splitNonUniform(self, splits, partitions=1, relativeCoords=False, depth=0, rankid=None):
-        """Split a fiber non-uniformly in coordinate space 
+        """Split a fiber non-uniformly in coordinate space
 
         Parameters
         ----------
@@ -3685,7 +3685,7 @@ class Fiber:
             cur_payloads = []
 
             for p in self.payloads:
-                cur_payloads.append(p.flattenRanks(levels=levels - 1))
+                cur_payloads.append(p.flattenRanks(levels=levels - 1, style=style))
 
         #
         # Flatten this level

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -26,7 +26,7 @@ class TestTensorTransform(unittest.TestCase):
                 self.assertEqual(a_out.getShape(), [26, 41, 42, 10])
 
 
-        
+
     def test_splitUniform_1(self):
         """ Test splitUniform - depth=1 """
 
@@ -255,7 +255,7 @@ class TestTensorTransform(unittest.TestCase):
     def test_swizzleRanks(self):
         """ Test swizzleRanks """
 
-        a_MK = Tensor.fromUncompressed(["M", "K"], 
+        a_MK = Tensor.fromUncompressed(["M", "K"],
                                [[0, 0, 4, 0, 0, 5],
                                 [3, 2, 0, 3, 0, 2],
                                 [0, 2, 0, 0, 1, 2],
@@ -326,7 +326,7 @@ class TestTensorTransform(unittest.TestCase):
 
         f01 = t0.flattenRanks(depth=0, levels=1)
         u01 = f01.unflattenRanks(depth=0, levels=1)
-        
+
         self.assertEqual(u01, t0)
 
     def test_flattenRanks_f02(self):
@@ -360,7 +360,7 @@ class TestTensorTransform(unittest.TestCase):
         t0 = Tensor.fromYAMLfile("./data/tensor_3d-0.yaml")
         t1 = Tensor.fromYAMLfile("./data/tensor_3d-1.yaml")
 
-        t2 = Tensor.fromFiber(["A", "B", "C", "D"], 
+        t2 = Tensor.fromFiber(["A", "B", "C", "D"],
                               Fiber([1, 4], [t0.getRoot(), t1.getRoot()]),
                               name="t2")
 
@@ -373,6 +373,18 @@ class TestTensorTransform(unittest.TestCase):
         u04 = f04.unflattenRanks(depth=0, levels=3)
 
         self.assertEqual(u04, t2)
+
+    def test_flattenRanks_l3_sa(self):
+        """Test flattenRanks - levels=3, coord_style=absolute"""
+        t0 = Tensor.fromUncompressed(rank_ids=["A"], root=list(range(16)))
+        s1 = t0.splitUniform(8, depth=0)
+        s2 = s1.splitUniform(4, depth=1)
+        s3 = s2.splitUniform(2, depth=2)
+
+        f4 = s3.flattenRanks(levels=3, coord_style="absolute")
+        f4.setRankIds(["A"])
+
+        self.assertEqual(f4, t0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR passes the `style` parameter from one `Fiber.flattenRanks` call to the next so that the specified style is used at all levels.

Note: There is some repeated changes from [this PR](https://github.com/Fibertree-Project/fibertree/pull/1), so merging may be a little annoying. If you give me write permission, I would be willing to resolve any merge conflicts once the actual changes are approved.