### PR TITLE
Fix and test Tensor.__truediv__() and Tensor.__floordiv__()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ debug.py
 *~
 \#*\#
 
+# Vim files
+*.swp
+
 #pycharm
 **/.idea/
 venv/

--- a/fibertree/core/tensor.py
+++ b/fibertree/core/tensor.py
@@ -1033,7 +1033,7 @@ class Tensor:
 
         """
 
-        return self.splitUniform(arg, depth=0)
+        return self._splitGeneric(Fiber.__truediv__, arg)
 
     def __floordiv__(self, arg):
         """Split root fiber in position space
@@ -1043,7 +1043,7 @@ class Tensor:
 
         """
 
-        return self.splitEqual(arg, depth=0)
+        return self._splitGeneric(Fiber.__floordiv__, arg)
 
 
     def splitUniform(self, *args, **kwargs):

--- a/fibertree/core/tensor.py
+++ b/fibertree/core/tensor.py
@@ -1033,12 +1033,7 @@ class Tensor:
 
         """
 
-        return self._splitGeneric(Fiber.__truediv__,
-                                  None,
-                                  arg,
-                                  depth=0)
-
-
+        return self.splitUniform(arg, depth=0)
 
     def __floordiv__(self, arg):
         """Split root fiber in position space
@@ -1048,11 +1043,7 @@ class Tensor:
 
         """
 
-        return self._splitGeneric(Fiber.__floordiv__,
-                                  None,
-                                  arg,
-                                  depth=0)
-
+        return self.splitEqual(arg, depth=0)
 
 
     def splitUniform(self, *args, **kwargs):

--- a/test/data/tensor_transform-b-floordiv.yaml
+++ b/test/data/tensor_transform-b-floordiv.yaml
@@ -1,0 +1,132 @@
+tensor:
+  name: tensor_transform-b-floordiv
+  rank_ids:
+  - M.1
+  - M.0
+  - N
+  root:
+  - fiber:
+      coords:
+      - 0
+      - 5
+      - 12
+      - 16
+      payloads:
+      - fiber:
+          coords:
+          - 0
+          - 1
+          payloads:
+          - fiber:
+              coords:
+              - 2
+              - 4
+              - 6
+              - 8
+              payloads:
+              - 8
+              - 7
+              - 1
+              - 10
+          - fiber:
+              coords:
+              - 0
+              - 2
+              - 3
+              - 5
+              payloads:
+              - 4
+              - 6
+              - 1
+              - 7
+      - fiber:
+          coords:
+          - 5
+          - 10
+          payloads:
+          - fiber:
+              coords:
+              - 4
+              - 6
+              - 7
+              payloads:
+              - 9
+              - 5
+              - 6
+          - fiber:
+              coords:
+              - 0
+              - 4
+              - 6
+              - 7
+              - 8
+              - 9
+              payloads:
+              - 8
+              - 4
+              - 3
+              - 6
+              - 9
+              - 3
+      - fiber:
+          coords:
+          - 12
+          - 14
+          payloads:
+          - fiber:
+              coords:
+              - 0
+              - 1
+              - 5
+              - 6
+              payloads:
+              - 1
+              - 5
+              - 3
+              - 4
+          - fiber:
+              coords:
+              - 3
+              - 7
+              payloads:
+              - 5
+              - 9
+      - fiber:
+          coords:
+          - 16
+          - 19
+          payloads:
+          - fiber:
+              coords:
+              - 0
+              - 2
+              - 3
+              - 4
+              - 8
+              payloads:
+              - 6
+              - 9
+              - 6
+              - 1
+              - 1
+          - fiber:
+              coords:
+              - 0
+              - 3
+              - 4
+              - 5
+              - 6
+              - 8
+              - 9
+              payloads:
+              - 9
+              - 2
+              - 1
+              - 5
+              - 2
+              - 5
+              - 3
+  shape:
+  - 17
+  - 20
+  - 10

--- a/test/data/tensor_transform-b-truediv.yaml
+++ b/test/data/tensor_transform-b-truediv.yaml
@@ -1,0 +1,132 @@
+tensor:
+  name: tensor_transform-b-truediv
+  rank_ids:
+  - M.1
+  - M.0
+  - N
+  root:
+  - fiber:
+      coords:
+      - 0
+      - 5
+      - 10
+      - 15
+      payloads:
+      - fiber:
+          coords:
+          - 0
+          - 1
+          payloads:
+          - fiber:
+              coords:
+              - 2
+              - 4
+              - 6
+              - 8
+              payloads:
+              - 8
+              - 7
+              - 1
+              - 10
+          - fiber:
+              coords:
+              - 0
+              - 2
+              - 3
+              - 5
+              payloads:
+              - 4
+              - 6
+              - 1
+              - 7
+      - fiber:
+          coords:
+          - 5
+          payloads:
+          - fiber:
+              coords:
+              - 4
+              - 6
+              - 7
+              payloads:
+              - 9
+              - 5
+              - 6
+      - fiber:
+          coords:
+          - 10
+          - 12
+          - 14
+          payloads:
+          - fiber:
+              coords:
+              - 0
+              - 4
+              - 6
+              - 7
+              - 8
+              - 9
+              payloads:
+              - 8
+              - 4
+              - 3
+              - 6
+              - 9
+              - 3
+          - fiber:
+              coords:
+              - 0
+              - 1
+              - 5
+              - 6
+              payloads:
+              - 1
+              - 5
+              - 3
+              - 4
+          - fiber:
+              coords:
+              - 3
+              - 7
+              payloads:
+              - 5
+              - 9
+      - fiber:
+          coords:
+          - 16
+          - 19
+          payloads:
+          - fiber:
+              coords:
+              - 0
+              - 2
+              - 3
+              - 4
+              - 8
+              payloads:
+              - 6
+              - 9
+              - 6
+              - 1
+              - 1
+          - fiber:
+              coords:
+              - 0
+              - 3
+              - 4
+              - 5
+              - 6
+              - 8
+              - 9
+              payloads:
+              - 9
+              - 2
+              - 1
+              - 5
+              - 2
+              - 5
+              - 3
+  shape:
+  - 16
+  - 20
+  - 10

--- a/test/data/tensor_transform-b.yaml
+++ b/test/data/tensor_transform-b.yaml
@@ -1,0 +1,114 @@
+tensor:
+  name: tensor_transform-b
+  rank_ids:
+  - M
+  - N
+  root:
+  - fiber:
+      coords:
+      - 0
+      - 1
+      - 5
+      - 10
+      - 12
+      - 14
+      - 16
+      - 19
+      payloads:
+      - fiber:
+          coords:
+          - 2
+          - 4
+          - 6
+          - 8
+          payloads:
+          - 8
+          - 7
+          - 1
+          - 10
+      - fiber:
+          coords:
+          - 0
+          - 2
+          - 3
+          - 5
+          payloads:
+          - 4
+          - 6
+          - 1
+          - 7
+      - fiber:
+          coords:
+          - 4
+          - 6
+          - 7
+          payloads:
+          - 9
+          - 5
+          - 6
+      - fiber:
+          coords:
+          - 0
+          - 4
+          - 6
+          - 7
+          - 8
+          - 9
+          payloads:
+          - 8
+          - 4
+          - 3
+          - 6
+          - 9
+          - 3
+      - fiber:
+          coords:
+          - 0
+          - 1
+          - 5
+          - 6
+          payloads:
+          - 1
+          - 5
+          - 3
+          - 4
+      - fiber:
+          coords:
+          - 3
+          - 7
+          payloads:
+          - 5
+          - 9
+      - fiber:
+          coords:
+          - 0
+          - 2
+          - 3
+          - 4
+          - 8
+          payloads:
+          - 6
+          - 9
+          - 6
+          - 1
+          - 1
+      - fiber:
+          coords:
+          - 0
+          - 3
+          - 4
+          - 5
+          - 6
+          - 8
+          - 9
+          payloads:
+          - 9
+          - 2
+          - 1
+          - 5
+          - 2
+          - 5
+          - 3
+  shape:
+  - 20
+  - 10

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -10,14 +10,14 @@ class TestTensorTransform(unittest.TestCase):
 
     def test_truediv(self):
         """ Test /, the __truediv__ operator """
-        a = Tensor.fromYAMLfile("./data/tensor_transform-a.yaml")
-        a_verify = Tensor.fromYAMLfile("./data/tensor_transform-a-splitUniform_0.yaml")
+        a = Tensor.fromYAMLfile("./data/tensor_transform-b.yaml")
+        a_verify = Tensor.fromYAMLfile("./data/tensor_transform-b-truediv.yaml")
 
-        a_out = a / 25
+        a_out = a / 4
 
         self.assertEqual(a_out, a_verify)
-        self.assertEqual(a_out.getRankIds(), ["M.1", "M.0", "N", "K"])
-        self.assertEqual(a_out.getShape(), [26, 41, 42, 10])
+        self.assertEqual(a_out.getRankIds(), ["M.1", "M.0", "N"])
+        self.assertEqual(a_out.getShape(), [16, 20, 10])
 
     def test_splitUniform_0(self):
         """ Test splitUniform - depth=0 """
@@ -128,14 +128,14 @@ class TestTensorTransform(unittest.TestCase):
 
     def test_floordiv(self):
         """ Test /, the __floordiv__ operator """
-        a = Tensor.fromYAMLfile("./data/tensor_transform-a.yaml")
-        a_verify = Tensor.fromYAMLfile("./data/tensor_transform-a-splitEqual_0.yaml")
+        a = Tensor.fromYAMLfile("./data/tensor_transform-b.yaml")
+        a_verify = Tensor.fromYAMLfile("./data/tensor_transform-b-floordiv.yaml")
 
-        a_out = a // 2
+        a_out = a // 4
 
         self.assertEqual(a_out, a_verify)
-        self.assertEqual(a_out.getRankIds(), ["M.1", "M.0", "N", "K"])
-        self.assertEqual(a_out.getShape(), [41, 41, 42, 10])
+        self.assertEqual(a_out.getRankIds(), ["M.1", "M.0", "N"])
+        self.assertEqual(a_out.getShape(), [17, 20, 10])
 
     def test_splitEqual_0(self):
         """ Test splitEqual - depth=0 """

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -8,6 +8,17 @@ from fibertree import Tensor
 
 class TestTensorTransform(unittest.TestCase):
 
+    def test_truediv(self):
+        """ Test /, the __truediv__ operator """
+        a = Tensor.fromYAMLfile("./data/tensor_transform-a.yaml")
+        a_verify = Tensor.fromYAMLfile("./data/tensor_transform-a-splitUniform_0.yaml")
+
+        a_out = a / 25
+
+        self.assertEqual(a_out, a_verify)
+        self.assertEqual(a_out.getRankIds(), ["M.1", "M.0", "N", "K"])
+        self.assertEqual(a_out.getShape(), [26, 41, 42, 10])
+
     def test_splitUniform_0(self):
         """ Test splitUniform - depth=0 """
 
@@ -26,7 +37,7 @@ class TestTensorTransform(unittest.TestCase):
                 self.assertEqual(a_out.getShape(), [26, 41, 42, 10])
 
 
-        
+
     def test_splitUniform_1(self):
         """ Test splitUniform - depth=1 """
 
@@ -115,6 +126,16 @@ class TestTensorTransform(unittest.TestCase):
                 self.assertEqual(a_out.getRankIds(), ["M", "N", "K.1", "K.0"])
                 self.assertEqual(a_out.getShape(), [41, 42, 5, 10])
 
+    def test_floordiv(self):
+        """ Test /, the __floordiv__ operator """
+        a = Tensor.fromYAMLfile("./data/tensor_transform-a.yaml")
+        a_verify = Tensor.fromYAMLfile("./data/tensor_transform-a-splitEqual_0.yaml")
+
+        a_out = a // 2
+
+        self.assertEqual(a_out, a_verify)
+        self.assertEqual(a_out.getRankIds(), ["M.1", "M.0", "N", "K"])
+        self.assertEqual(a_out.getShape(), [41, 41, 42, 10])
 
     def test_splitEqual_0(self):
         """ Test splitEqual - depth=0 """
@@ -255,7 +276,7 @@ class TestTensorTransform(unittest.TestCase):
     def test_swizzleRanks(self):
         """ Test swizzleRanks """
 
-        a_MK = Tensor.fromUncompressed(["M", "K"], 
+        a_MK = Tensor.fromUncompressed(["M", "K"],
                                [[0, 0, 4, 0, 0, 5],
                                 [3, 2, 0, 3, 0, 2],
                                 [0, 2, 0, 0, 1, 2],
@@ -326,7 +347,7 @@ class TestTensorTransform(unittest.TestCase):
 
         f01 = t0.flattenRanks(depth=0, levels=1)
         u01 = f01.unflattenRanks(depth=0, levels=1)
-        
+
         self.assertEqual(u01, t0)
 
     def test_flattenRanks_f02(self):
@@ -360,7 +381,7 @@ class TestTensorTransform(unittest.TestCase):
         t0 = Tensor.fromYAMLfile("./data/tensor_3d-0.yaml")
         t1 = Tensor.fromYAMLfile("./data/tensor_3d-1.yaml")
 
-        t2 = Tensor.fromFiber(["A", "B", "C", "D"], 
+        t2 = Tensor.fromFiber(["A", "B", "C", "D"],
                               Fiber([1, 4], [t0.getRoot(), t1.getRoot()]),
                               name="t2")
 


### PR DESCRIPTION
This PR fixes `Tensor.__truediv__()` and `Tensor.__floordiv__()`, both of which seem to have been silently broken. In both cases, a `depth` parameter was being passed to the corresponding `Fiber` function, raising an error. The PR fixes this error and adds tests for both methods to prevent this sort of silent failure in the future.

Note: Some of the same repeated changes appear in this PR.