### PR TITLE
Allow empty fibers to be split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ debug.py
 *~
 \#*\#
 
+# Vim files
+*.swp
+
 #pycharm
 **/.idea/
 venv/

--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -138,7 +138,7 @@ class Fiber:
 
     """
 
-   
+
     def __init__(self,
                  coords=None,
                  payloads=None,
@@ -477,7 +477,7 @@ class Fiber:
         `Fiber.payloads` class instance variable directly.
 
         """
-        
+
         return self.payloads
 
 
@@ -1023,7 +1023,7 @@ class Fiber:
 
         TBD
         ----
-        
+
         Add support for **shortcuts**.
 
         """
@@ -1272,7 +1272,7 @@ class Fiber:
         next_default: a payload (boxed or unboxed)
             If `default` is a Fiber then a default payload for that fiber
 
-        addtorank: Boolean 
+        addtorank: Boolean
             If the newly created value is a fiber, then should that fiber
             be added to the its owning rank (owner.next_rank)
 
@@ -1834,7 +1834,7 @@ class Fiber:
         Nothing
 
         """
-        
+
         self.coords.clear()
         self.payloads.clear()
 
@@ -2493,7 +2493,7 @@ class Fiber:
 
 
     def splitUniform(self, step, partitions=1, relativeCoords=False, depth=0, rankid=None):
-        """Split a fiber uniformly in coordinate space 
+        """Split a fiber uniformly in coordinate space
 
         Parameters
         ----------
@@ -2559,7 +2559,7 @@ class Fiber:
 
 
     def splitNonUniform(self, splits, partitions=1, relativeCoords=False, depth=0, rankid=None):
-        """Split a fiber non-uniformly in coordinate space 
+        """Split a fiber non-uniformly in coordinate space
 
         Parameters
         ----------
@@ -2864,7 +2864,9 @@ class Fiber:
         # For 1 partition don't return a extra level of Fiber
 
         if partitions == 1:
-            return Fiber(rank1_fiber_coords[0], rank1_fiber_payloads[0])
+            fiber = Fiber(rank1_fiber_coords[0], rank1_fiber_payloads[0])
+            fiber._setDefault(Fiber())
+            return fiber
 
         # For >1 partitions return a Fiber with a payload for each partition
 

--- a/test/test_fiber_split.py
+++ b/test/test_fiber_split.py
@@ -6,6 +6,15 @@ from fibertree import TensorImage
 
 class TestFiberSplit(unittest.TestCase):
 
+    def test_split_uniform_empty(self):
+        """Test splitUniform on empty fiber"""
+        empty = Fiber()
+        split = empty.splitUniform(5)
+
+        # After we split, we need to make sure that we have actually added
+        # another level to the empty fiber
+        self.assertIsInstance(split.getDefault(), Fiber)
+
     def test_split_uniform(self):
         """Test splitUniform"""
 
@@ -14,7 +23,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [ 0, 10, 20, 100, 120, 310, 410 ]
-        
+
         f = Fiber(c,p)
 
         #
@@ -49,7 +58,7 @@ class TestFiberSplit(unittest.TestCase):
         for i, (sc, sp)  in enumerate(split):
             self.assertEqual(sc, split_ref_coords[i])
             self.assertEqual(sp, split_ref_payloads[i])
-        
+
 
     def test_split_uniform_then_flatten(self):
         """Test that flattenRanks() can undo splitUniform"""
@@ -59,7 +68,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [ 0, 10, 20, 100, 120, 310, 410 ]
-        
+
         f = Fiber(c,p)
 
         #
@@ -72,7 +81,7 @@ class TestFiberSplit(unittest.TestCase):
         # Check that flattening after splitting gives us the same answer
         #
         self.assertEqual(split.flattenRanks(style="absolute"), f)
-        
+
 
     def test_split_uniform_relative(self):
         """Test splitUniform"""
@@ -141,6 +150,15 @@ class TestFiberSplit(unittest.TestCase):
         #
         self.assertEqual(split.flattenRanks(style="relative"), f)
 
+    def test_split_nonuniform_empty(self):
+        """Test splitNonUniform on empty fiber"""
+        empty = Fiber()
+        split = empty.splitNonUniform([1, 5, 17])
+
+        # After we split, we need to make sure that we have actually added
+        # another level to the empty fiber
+        self.assertIsInstance(split.getDefault(), Fiber)
+
     def test_split_nonuniform1(self):
         """Test splitNonUniform - starting at coordinate 0"""
 
@@ -149,7 +167,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [ 0, 10, 20, 100, 120, 310, 410 ]
-        
+
         f = Fiber(c,p)
 
         #
@@ -229,7 +247,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [ 0, 10, 20, 100, 120, 310, 410 ]
-        
+
         f = Fiber(c,p)
 
         #
@@ -242,7 +260,17 @@ class TestFiberSplit(unittest.TestCase):
         # Check the split
         #
         self.assertEqual(split.flattenRanks(style="absolute"), f)
-        
+
+    def test_split_equal_empty(self):
+        """Test splitEqual on empty fiber"""
+        empty = Fiber()
+        split = empty.splitEqual(3)
+
+        # After we split, we need to make sure that we have actually added
+        # another level to the empty fiber
+        self.assertIsInstance(split.getDefault(), Fiber)
+
+
     def test_split_equal(self):
         """Test splitEqual"""
 
@@ -251,7 +279,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [ 0, 10, 20, 100, 120, 310, 410 ]
-        
+
         f = Fiber(c,p)
 
         #
@@ -275,7 +303,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         # Do the split
         #
-        size = 2 
+        size = 2
         split = f.splitEqual(size)
 
         #
@@ -284,7 +312,7 @@ class TestFiberSplit(unittest.TestCase):
         for i, (sc, sp)  in enumerate(split):
             self.assertEqual(sc, css[i][0])
             self.assertEqual(sp, split_ref[i])
-        
+
     def test_split_equal_then_flatten(self):
         """Test that flattenRanks can undo splitEqual"""
 
@@ -293,20 +321,30 @@ class TestFiberSplit(unittest.TestCase):
         #
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [ 0, 10, 20, 100, 120, 310, 410 ]
-        
+
         f = Fiber(c,p)
 
         #
         # Do the split
         #
-        size = 2 
+        size = 2
         split = f.splitEqual(size)
 
         #
         # Check the split
         #
         self.assertEqual(split.flattenRanks(style="absolute"), f)
-        
+
+    def test_split_unequal_empty(self):
+        """Test splitUnEqual on empty fiber"""
+        empty = Fiber()
+        split = empty.splitUnEqual([1, 5, 17])
+
+        # After we split, we need to make sure that we have actually added
+        # another level to the empty fiber
+        self.assertIsInstance(split.getDefault(), Fiber)
+
+
     def test_split_unequal(self):
         """Test splitUnequal"""
 
@@ -315,7 +353,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [ 0, 10, 20, 100, 120, 310, 410 ]
-        
+
         f = Fiber(c,p)
 
         #
@@ -346,7 +384,7 @@ class TestFiberSplit(unittest.TestCase):
         for i, (sc, sp)  in enumerate(split):
             self.assertEqual(sc, css[i][0])
             self.assertEqual(sp, split_ref[i])
-        
+
 
     def test_split_unequal_then_flatten(self):
         """Test that flattenRanks can undo splitUnequal"""
@@ -356,7 +394,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [ 0, 10, 20, 100, 120, 310, 410 ]
-        
+
         f = Fiber(c,p)
 
         #
@@ -369,8 +407,8 @@ class TestFiberSplit(unittest.TestCase):
         # Check the split
         #
         self.assertEqual(split.flattenRanks(style="absolute"), f)
-        
-        
+
+
     def test_split_equal_partioned(self):
         """Test splitEqual(2, partitions=2)"""
 
@@ -379,7 +417,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [ 0, 10, 20, 100, 120, 310, 410 ]
-        
+
         f = Fiber(c,p)
 
         #
@@ -410,7 +448,7 @@ class TestFiberSplit(unittest.TestCase):
 
     @staticmethod
     def _make_fiber_a():
-        
+
         f = Fiber([0, 1, 2, 10, 12, 31, 41], [ 0, 10, 20, 100, 120, 310, 410 ])
         return f
 


### PR DESCRIPTION
Currently, the following code fails:

```
Z_M = Tensor(rank_ids=["M"])

z_m = Z_M.getRoot()
a_m = A_M.getRoot()
b_m = B_M.getRoot()

a_m1 = a_m.splitEqual(3)
b_m1 = b_m.splitNonUniform(a_m1)
z_m1 = z_m.splitNonUniform(a_m1)

for m1, (z_m0, (a_m0, b_m0)) in z_m1 << (a_m1 & b_m1):
    for m0, (z_ref, (a_val, b_val)) in z_m0 << (a_m0 & b_m0):
        z_ref += a_val + b_val
```
on the line:
```
for m0, (z_ref, (a_val, b_val)) in z_m0 << (a_m0 & b_m0):
```
because it is trying to do the `<<` operator with an `int` and a `Fiber`. After splitting, the default payload must always be a Fiber to avoid this issue.

Note: There are again some repeated changes.