### PR TITLE
Propagate mutable property and allow empty Tensors to be unflattened

### DIFF
--- a/fibertree/core/tensor.py
+++ b/fibertree/core/tensor.py
@@ -1194,6 +1194,7 @@ class Tensor:
         tensor = Tensor.fromFiber(rank_ids, root, shape)
         tensor.setName(self.getName() + "+split")
         tensor.setColor(self.getColor())
+        tensor.setMutable(self.isMutable())
 
         return tensor
 
@@ -1296,6 +1297,7 @@ class Tensor:
         tensor = Tensor.fromFiber(rank_ids, root, shape)
         tensor.setName(self.getName() + "+swapped")
         tensor.setColor(self.getColor())
+        tensor.setMutable(self.isMutable())
 
         return tensor
 
@@ -1362,6 +1364,7 @@ class Tensor:
         tensor = Tensor.fromFiber(rank_ids, root, shape)
         tensor.setName(self.getName() + "+flattened")
         tensor.setColor(self.getColor())
+        tensor.setMutable(self.isMutable())
 
         return tensor
 
@@ -1408,16 +1411,22 @@ class Tensor:
         #
         shape = None
 
-        root = self._modifyRoot(Fiber.unflattenRanks,
-                                Fiber.unflattenRanksBelow,
-                                depth=depth,
-                                levels=levels)
+        # Only call Fiber.unflattenRanks if there are actually ranks to unflatten
+        if not all(fiber.isEmpty() for fiber in self.ranks[depth].fibers):
+            root = self._modifyRoot(Fiber.unflattenRanks,
+                                    Fiber.unflattenRanksBelow,
+                                    depth=depth,
+                                    levels=levels)
+        else:
+            root = Fiber()
+
         #
         # Create Tensor from rank_ids and root fiber
         #
         tensor = Tensor.fromFiber(rank_ids, root, shape)
         tensor.setName(self.getName() + "+unflattened")
         tensor.setColor(self.getColor())
+        tensor.setMutable(self.isMutable())
 
         return tensor
 

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -579,6 +579,55 @@ class TestTensor(unittest.TestCase):
 
         self.assertTrue(tensor == tensor_tmp)
 
+    def test_init_mutable(self):
+        t = Tensor.fromYAMLfile("./data/test_tensor-1.yaml")
+        self.assertFalse(t.isMutable())
+
+        t2 = Tensor(rank_ids=["X", "Y", "Z"])
+        self.assertTrue(t2.isMutable())
+
+    def test_mutable(self):
+        t = Tensor.fromYAMLfile("./data/test_tensor-1.yaml")
+        t.setMutable(True)
+        self.assertTrue(t.isMutable())
+
+    def test_mutable_after_split(self):
+        t = Tensor.fromYAMLfile("./data/test_tensor-1.yaml")
+        t2 = t.splitUniform(10)
+        self.assertFalse(t2.isMutable())
+
+        t3 = Tensor(rank_ids=["X", "Y", "Z"])
+        t4 = t3.splitUniform(10)
+        self.assertTrue(t4.isMutable())
+
+    def test_mutable_after_swap(self):
+        t = Tensor.fromYAMLfile("./data/test_tensor-1.yaml")
+        t2 = t.swapRanks()
+        self.assertFalse(t2.isMutable())
+
+        t3 = Tensor(rank_ids=["X", "Y", "Z"])
+        t4 = t3.swapRanks()
+        self.assertTrue(t4.isMutable())
+
+    def test_mutable_after_flatten(self):
+        t = Tensor.fromYAMLfile("./data/test_tensor-1.yaml")
+        t2 = t.flattenRanks()
+        self.assertFalse(t2.isMutable())
+
+        t3 = Tensor(rank_ids=["X", "Y", "Z"])
+        t4 = t3.flattenRanks()
+        self.assertTrue(t4.isMutable())
+
+    def test_mutable_after_unflatten(self):
+        t = Tensor.fromYAMLfile("./data/test_tensor-1.yaml")
+        t2 = t.flattenRanks()
+        t3 = t2.unflattenRanks()
+        self.assertFalse(t3.isMutable())
+
+        t4 = Tensor(rank_ids=["X", "Y", "Z"])
+        t5 = t4.flattenRanks()
+        t6 = t5.unflattenRanks()
+        self.assertTrue(t6.isMutable())
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -415,6 +415,13 @@ class TestTensorTransform(unittest.TestCase):
 
         self.assertEqual(f4, t0)
 
+    def test_unflattenRanks_empty(self):
+        t = Tensor(rank_ids=["X", "Y", "Z"])
+        t2 = t.flattenRanks()
+        t3 = t2.unflattenRanks()
+        t3.setRankIds(["X", "Y", "Z"])
+
+        self.assertEqual(t, t3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR allows tensors mutable before splitting, swapping, flattening, and unflattening should be mutable afterwards and vice versa if they were not before. Additionally, the PR allows empty tensors to be unflattened without an error.