### PR TITLE
Support the display of a single tuple of coordinates

### DIFF
--- a/fibertree/graphics/tensor_canvas.py
+++ b/fibertree/graphics/tensor_canvas.py
@@ -249,7 +249,7 @@ class TensorCanvas():
         highlights_list = []
 
         for hl in highlights:
-            highlights_list.append(HighlightManager.canonicalizeHighlights(hl, worker=worker))
+            highlights_list.append(HighlightManager.canonicalizeHighlights([hl], worker=worker))
 
         #
         # If wait is a list it is a list of input tensors that this


### PR DESCRIPTION
Fix the display of the following kernel:
```
Z_MN = Tensor(rank_ids=["MN"])
z_mn = Z_MN.getRoot()
tmp0 = A_MN
tmp1 = tmp0.flattenRanks(depth=0, levels=1, coord_style="tuple")
A_MN_flat = tmp1
A_MN_flat.setRankIds(rank_ids=["MN"])
canvas = createCanvas(A_MN_flat, Z_MN)
a_mn = A_MN_flat.getRoot()
for mn_pos, ((m, n), (z_ref, a_val)) in enumerate(z_mn << a_mn):
    z_ref += a_val
    canvas.addActivity(((m, n),), ((m, n),), spacetime=((), (mn_pos,)))
tmp2 = Z_MN
tmp3 = tmp2.unflattenRanks(depth=0, levels=1)
tmp3.setRankIds(rank_ids=["M", "N"])
Z_MN = tmp3
displayCanvas(canvas)
```
Note that this change is untested because there is no where to add tests.