### PR TITLE
Support Non-Zero Default Values with Payload.isEmpty

### DIFF
--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -1781,7 +1781,7 @@ class Fiber:
             if Payload.contains(p, Fiber):
                 count += Payload.get(p).countValues()
             else:
-                count += 1 if not Payload.isEmpty(p) else 0
+                count += 1 if not Payload.isEmpty(p, default=self.getDefault()) else 0
 
         return count
 
@@ -2014,7 +2014,7 @@ class Fiber:
         """
         assert not self.isLazy()
 
-        return all(map(Payload.isEmpty, self.payloads))
+        return all(map(lambda p: Payload.isEmpty(p, default=self.getDefault()), self.payloads))
 
 
     def nonEmpty(self):
@@ -2038,7 +2038,7 @@ class Fiber:
         payloads = []
 
         for c, p in zip(self.coords, self.payloads):
-            if not Payload.isEmpty(p):
+            if not Payload.isEmpty(p, default=self.getDefault()):
                 coords.append(c)
                 if Payload.contains(p, Fiber):
                     payloads.append(p.nonEmpty())
@@ -2807,14 +2807,6 @@ class Fiber:
 
         self._setDefault(other.getDefault())
         for c, p in other:
-            #
-            # For each non-empty element of other, insert it into the
-            # target, note that this works regardless of whether p is
-            # a Fiber or a Payload
-            #
-            if Payload.isEmpty(p):
-                continue
-
             ref = self.getPayloadRef(c)
             ref <<= p
 
@@ -4456,10 +4448,10 @@ class Fiber:
             return False
 
         for c, (mask, ps, po) in self | other:
-            if mask == "A" and not Payload.isEmpty(ps):
+            if mask == "A":
                 return False
 
-            if mask == "B" and not Payload.isEmpty(po):
+            if mask == "B":
                 return False
 
             if mask == "AB" and not (ps == po):

--- a/fibertree/core/iterators.py
+++ b/fibertree/core/iterators.py
@@ -167,7 +167,7 @@ def iterRange(self, start, end, tick=True, start_pos=None):
 
         # If we are within the range, emit the non-default elements
         elif start is None or coord >= start:
-            if not Payload.isEmpty(payload):
+            if not Payload.isEmpty(payload, default=self.getDefault()):
                 if start_pos is not None:
                     self.setSavedPos(i + j, distance=j)
 

--- a/fibertree/core/payload.py
+++ b/fibertree/core/payload.py
@@ -189,7 +189,7 @@ class Payload:
 # Static methods
 #
     @staticmethod
-    def isEmpty(p):
+    def isEmpty(p, default=0):
         """Check if a fiber element's payload is empty.
 
         Selectively look into the given argument (`p`) to see if it is
@@ -219,10 +219,7 @@ class Payload:
         if type(p).__name__ == "Fiber":
             return p.isEmpty()
 
-        if isinstance(p, tuple):
-            assert isinstance(p, tuple)
-
-        if (p == 0):
+        if p == default:
             return True
 
         return False

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -1,5 +1,6 @@
 import unittest
 
+from fibertree import Fiber
 from fibertree import Metrics
 from fibertree import Payload
 
@@ -141,6 +142,13 @@ class TestPayload(unittest.TestCase):
         self.assertFalse(8 != c)
         self.assertTrue(1 != c)
 
+    def test_isEmpty(self):
+        self.assertTrue(Payload.isEmpty(Fiber()))
+        self.assertFalse(Payload.isEmpty(Fiber([0, 1, 3], [4, 3, 6])))
+
+        self.assertTrue(Payload.isEmpty(0))
+        self.assertFalse(Payload.isEmpty(5))
+        self.assertTrue(Payload.isEmpty(5, default=5))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Support any specified default value with `Payload.isEmpty` and its uses.

Fixes the following code snippet, provided by @Malloc26:

```
# Empty not working example for Nandeeka
# I traced it and problem seems to be in the Payload class, 
# where `empty` is always defined as 0 instead of the default value

F= Tensor.fromUncompressed(["S"], [True, False, False, False], name="F",
                                   color="blue")
F.setDefault(False)
f_s = F.getRoot()


B = Tensor(rank_ids=["D"], shape=[4],
                default=math.inf)
B.setName("B")
b_s = B.getRoot()
print(repr(b_s))


#For B, math.inf is the empty value, 
# but 0 should be a valid value that populates the tensor
for s, (b_ref, f_val) in \
        b_s << f_s:
    b_ref <<= 0
    print("I set b_ref!", b_ref)

displayTensor(F)
print("This is showing an empty tensor instead of coordinate 0 with value 0")
displayTensor(B)
print("Default value of B is ", B.getDefault())

#This doesn't work! 
print(b_s.coords)
print(b_s.payloads)
for s, b_val in b_s.prune(lambda pos, coord, val: val == 0):
    print("B contains a 0 value!", s, b_val)
```