### PR TITLE
draw root only for empty sparse tree

### DIFF
--- a/fibertree/graphics/tree_image.py
+++ b/fibertree/graphics/tree_image.py
@@ -151,6 +151,9 @@ class TreeImage():
                              Payload.get(root),
                              hl)
             region_end = 1
+        elif root.countValues() == 0:
+            self._draw_coord(0, 0, "R")
+            region_end = 1
         else:
             #
             # Draw a non-0-D tensor or a fiber, i.e., the fiber tree

--- a/fibertree/graphics/tree_image.py
+++ b/fibertree/graphics/tree_image.py
@@ -416,7 +416,10 @@ class TreeImage():
         y2 = y1 + height
         fill_color = (128,128,128) if not highlight else (233,198,109)
 
-        self.draw.ellipse(((x1, y1), (x2, y2)), fill_color, (0, 0, 0))
+        self.draw.rounded_rectangle(((x1, y1), (x2, y2)),
+                                    radius=30,
+                                    fill=fill_color,
+                                    outline=(0, 0, 0))
 
 
     def _draw_coord(self, level, offset, coord, highlight=[]):


### PR DESCRIPTION
Currently crashes instead.