### PR TITLE
Improve metrics counting and support non-zero defaults

### DIFF
--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -3970,16 +3970,13 @@ class Fiber:
         coords = [c for c, _ in sorted_cp]
         payloads = [p for _, p in sorted_cp]
 
-        flattened_sorted = Fiber(coords, payloads)
+        flattened_sorted = Fiber(coords, payloads, default=flattened.getDefault())
 
         #
         # Unflatten to get original coordinates in swapped ranks
         #
         swapped = flattened_sorted.unflattenRanks()
 
-        #
-        # TBD: set default
-        #
         return swapped
 
 

--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -4457,7 +4457,7 @@ class Fiber:
             if mask == "B":
                 return False
 
-            if mask == "AB" and not (ps == po):
+            if mask == "AB" and ps != po:
                 return False
 
         return True

--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -717,7 +717,7 @@ class Fiber:
             payload = Payload.maybe_box(default)
             const_used = True
 
-        if Metrics.isCollecting():
+        if Metrics.isCollecting() and trace is not None:
             Metrics.addUse(self.getRankAttrs().getId(), coords[0], index, type_=trace)
 
         if not const_used and len(coords) > 1:
@@ -2810,7 +2810,6 @@ class Fiber:
             #
             self.coords = []
             self.payloads = []
-
 
         self._setDefault(other.getDefault())
         for c, p in other:

--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -3858,7 +3858,7 @@ class Fiber:
         upper = Fiber(default=Fiber(), active_range=self.getActive())
 
         for part, coords, payloads, active_range in splitter(self):
-            lower = Fiber(coords=coords, payloads=payloads, active_range=active_range)
+            lower = Fiber(coords=coords, payloads=payloads, active_range=active_range, default=self.getDefault())
             upper.coords.append(part)
             upper.payloads.append(lower)
 

--- a/fibertree/core/iterators.py
+++ b/fibertree/core/iterators.py
@@ -207,7 +207,7 @@ def iterRangeShape(self, start, end, step=1, tick=True):
     is_collecting, rank = _prep_metrics_inc(self)
 
     if is_collecting and tick:
-        self.registerRank(rank)
+        Metrics.registerRank(rank)
 
     for c in range(start, end, step):
         p = self.getPayload(c)
@@ -241,7 +241,7 @@ def iterRangeShapeRef(self, start, end, step=1, tick=True):
     is_collecting, rank = _prep_metrics_inc(self)
 
     if is_collecting and tick:
-        self.registerRank(rank)
+        Metrics.registerRank(rank)
 
     for c in range(start, end, step):
         p = self.getPayloadRef(c)

--- a/fibertree/core/metrics.py
+++ b/fibertree/core/metrics.py
@@ -90,7 +90,6 @@ class Metrics:
         if iteration_num is None:
             iteration_num = cls.iteration
 
-
         iteration = iteration_num[:(i + 1)]
         point = cls.point[:i] + [coord]
 

--- a/fibertree/core/payload.py
+++ b/fibertree/core/payload.py
@@ -472,6 +472,10 @@ class Payload:
 
         """
 
+        # Collect metrics
+        if Metrics.isCollecting():
+            Metrics.incCount("Compute", "payload_update", 1)
+
         if isinstance(other, Payload):
             self.value = other.value
         else:

--- a/fibertree/core/payload.py
+++ b/fibertree/core/payload.py
@@ -411,6 +411,7 @@ class Payload:
 
     def __iadd__(self, other):
         """__iadd__"""
+        old = self.value
 
         if isinstance(other, Payload):
             self.value = self.value + other.value
@@ -419,8 +420,9 @@ class Payload:
 
         # Collect metrics
         if Metrics.isCollecting():
-            Metrics.incCount("Compute", "payload_add", 1)
             Metrics.incCount("Compute", "payload_update", 1)
+            if old != 0:
+                Metrics.incCount("Compute", "payload_add", 1)
 
         return self
 

--- a/fibertree/core/tensor.py
+++ b/fibertree/core/tensor.py
@@ -1503,6 +1503,7 @@ class Tensor:
         tensor.setName(self.getName() + "+flattened")
         tensor.setColor(self.getColor())
         tensor.setMutable(self.isMutable())
+        tensor.setDefault(self.getDefault())
 
         # Maintain the formats for unflattened rank_ids
         # Compress everything else
@@ -1543,6 +1544,7 @@ class Tensor:
         tensor.setName(self.getName() + "+merged")
         tensor.setColor(self.getColor())
         tensor.setMutable(self.isMutable())
+        tensor.setDefault(self.getDefault())
 
         # Maintain the formats for unmerged rank_ids
         # Compress everything else

--- a/fibertree/core/tensor.py
+++ b/fibertree/core/tensor.py
@@ -1402,7 +1402,7 @@ class Tensor:
             last_coord = coord
 
         # Build the new tensor
-        kwargs = {"fiber": root, "rank_ids": rank_ids}
+        kwargs = {"fiber": root, "rank_ids": rank_ids, "default": self.getDefault()}
         old_shape = self.getShape(authoritative=True)
         if old_shape:
             new_shape = [old_shape[guide[i]] for i in range(swiz_len)] \
@@ -1466,6 +1466,7 @@ class Tensor:
         tensor.setName(self.getName() + "+swapped")
         tensor.setColor(self.getColor())
         tensor.setMutable(self.isMutable())
+        tensor.setDefault(self.getDefault())
 
         # Maintain the formats
         for rank_id in tensor.getRankIds():

--- a/fibertree/core/tensor.py
+++ b/fibertree/core/tensor.py
@@ -277,7 +277,8 @@ class Tensor:
                   fiber=None,
                   shape=None,
                   name="",
-                  color="red"):
+                  color="red",
+                  default=0):
         """Construct a tensor from a fiber
 
         Parameters
@@ -319,7 +320,8 @@ class Tensor:
         tensor = cls(rank_ids=rank_ids,
                      shape=shape,
                      name=name,
-                     color=color)
+                     color=color,
+                     default=default)
 
         tensor.setRoot(fiber)
 
@@ -1287,6 +1289,7 @@ class Tensor:
         tensor.setName(self.getName() + "+split")
         tensor.setColor(self.getColor())
         tensor.setMutable(self.isMutable())
+        tensor.setDefault(self.getDefault())
 
         # Maintain the formats
         for rank_id in tensor.getRankIds():

--- a/fibertree/model/format.py
+++ b/fibertree/model/format.py
@@ -108,6 +108,10 @@ class Format:
 
         return self.spec[rank]["fhbits"]
 
+    def getFormat(self, rank):
+        """Get the format of the given rank; either "C" or "U" """
+        return self.spec[rank]["format"]
+
     def getLayout(self, rank):
         """Get the layout of this rank"""
         return self.spec[rank]["layout"]

--- a/test/test_fiber.py
+++ b/test/test_fiber.py
@@ -3193,6 +3193,17 @@ class TestFiber(unittest.TestCase):
         self.assertEqual(mf.getShape(), [10, 10])
         self.assertEqual(mf.getActive(), (0, 10))
 
+    def test_merge_preserves_default(self):
+        """Test that mergeRanks merges together fibers while preserving an explicit default"""
+        f = Fiber([0, 1, 4, 5],
+                  [Fiber([0, 1, 2], [1, 2, 3], shape=10, default=float("inf")),
+                   Fiber([1, 3, 4], [4, 5, 6], shape=10, default=float("inf")),
+                   Fiber([4, 7], [7, 8], shape=10, default=float("inf")),
+                   Fiber([5, 7], [9, 10], shape=10, default=float("inf"))],
+                  shape=10)
+        mf = f.mergeRanks()
+
+        self.assertEqual(mf.getDefault(), float("inf"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_fiber.py
+++ b/test/test_fiber.py
@@ -927,6 +927,23 @@ class TestFiber(unittest.TestCase):
             self.assertEqual(a.coords, c0)
             self.assertEqual(a.payloads, p0)
 
+    def test_iterRangeShape_metrics(self):
+        """Test that iterRangeShape correctly registers the rank"""
+
+        c0 = [1, 4, 8, 9]
+        p0 = [2, 3, 0, 10]
+
+        c0_ans = [2, 4, 6, 8]
+        p0_ans = [0, 3, 0, 0]
+
+        a = Fiber(c0, p0)
+        a.getRankAttrs().setId("M")
+
+        Metrics.beginCollect("tmp/test_iterRangeShape_metrics")
+        for _ in a.iterRangeShape(2, 9, 2):
+            self.assertEqual(Metrics.loop_order, ["M"])
+        Metrics.endCollect()
+
     def test_iterRangeShape_eager_only(self):
         """Test iterRangeShape only works in eager mode"""
 
@@ -975,6 +992,22 @@ class TestFiber(unittest.TestCase):
         with self.assertRaises(AssertionError):
             next(a.iterRangeShapeRef(2, 9))
 
+    def test_iterRangeShapeRef_metrics(self):
+        """Test that iterRangeShapeRef correctly registers the rank"""
+
+        c0 = [1, 4, 8, 9]
+        p0 = [2, 3, 0, 10]
+
+        c0_ans = [2, 4, 6, 8]
+        p0_ans = [0, 3, 0, 0]
+
+        a = Fiber(c0, p0)
+        a.getRankAttrs().setId("M")
+
+        Metrics.beginCollect("tmp/test_iterRangeShape_metrics")
+        for _ in a.iterRangeShapeRef(2, 9, 2):
+            self.assertEqual(Metrics.loop_order, ["M"])
+        Metrics.endCollect()
     def test_coiterShape(self):
         """Test coiterShape"""
         c0 = [1, 4, 8, 9]

--- a/test/test_fiber.py
+++ b/test/test_fiber.py
@@ -1659,6 +1659,68 @@ class TestFiber(unittest.TestCase):
         with self.assertRaises(AssertionError):
             a.getPayload(3)
 
+    def test_getPayload_metrics_1D(self):
+        """Test the tracing of metrics when there is a getPayload"""
+        coords = [2, 4, 6]
+        payloads = [3, 5, 7]
+
+        a = Fiber(coords, payloads)
+        a.getRankAttrs().setId("K")
+
+        Metrics.beginCollect("tmp/test_getPayload_metrics_1D")
+        Metrics.trace("K", type_="A")
+        Metrics.registerRank("K")
+
+        a.getPayload(2)
+        Metrics.incIter("K")
+        a.getPayload(2, trace="A")
+        Metrics.incIter("K")
+        a.getPayload(5, trace="A")
+
+        Metrics.endCollect()
+
+        corr = [
+            "K_pos,K,fiber_pos\n",
+            "1,2,0\n",
+            "2,5,2\n"
+        ]
+
+        with open("tmp/test_getPayload_metrics_1D-K-A.csv", "r") as f:
+            self.assertEqual(f.readlines(), corr)
+
+
+    def test_getPayload_metrics_2D(self):
+        """Test the tracing of metrics when there is a getPayload in 2D"""
+        a1 = [[1, 2, 3, 0],
+              [1, 0, 3, 4],
+              [0, 2, 3, 4],
+              [1, 2, 0, 4]]
+
+        t = Tensor.fromUncompressed(rank_ids=["K", "M"], root=a1)
+        a = t.getRoot()
+
+        Metrics.beginCollect("tmp/test_getPayload_metrics_2D")
+        Metrics.trace("M", type_="A")
+        Metrics.registerRank("K")
+        Metrics.registerRank("M")
+
+        a.getPayload(2, 1)
+        Metrics.incIter("K")
+        a.getPayload(2, 3, trace="A")
+        Metrics.incIter("M")
+        a.getPayload(1, 2, trace="A")
+
+        Metrics.endCollect()
+
+        corr = [
+            "K_pos,M_pos,K,M,fiber_pos\n",
+            "1,0,2,3,2\n",
+            "1,1,1,2,1\n"
+        ]
+
+        with open("tmp/test_getPayload_metrics_2D-M-A.csv", "r") as f:
+            self.assertEqual(f.readlines(), corr)
+
 
     def test_getPayloadRef_update(self):
         """Update payload references"""
@@ -1691,6 +1753,68 @@ class TestFiber(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             a.getPayloadRef(3)
+
+    def test_getPayloadRef_metrics_1D(self):
+        """Test the tracing of metrics when there is a getPayloadRef"""
+        coords = [2, 4, 6]
+        payloads = [3, 5, 7]
+
+        a = Fiber(coords, payloads)
+        a.getRankAttrs().setId("K")
+
+        Metrics.beginCollect("tmp/test_getPayloadRef_metrics_1D")
+        Metrics.trace("K", type_="A")
+        Metrics.registerRank("K")
+
+        a.getPayloadRef(2)
+        Metrics.incIter("K")
+        a.getPayloadRef(2, trace="A")
+        Metrics.incIter("K")
+        a.getPayloadRef(5, trace="A")
+
+        Metrics.endCollect()
+
+        corr = [
+            "K_pos,K,fiber_pos\n",
+            "1,2,0\n",
+            "2,5,2\n"
+        ]
+
+        with open("tmp/test_getPayloadRef_metrics_1D-K-A.csv", "r") as f:
+            self.assertEqual(f.readlines(), corr)
+
+
+    def test_getPayloadRef_metrics_2D(self):
+        """Test the tracing of metrics when there is a getPayloadRef in 2D"""
+        a1 = [[1, 2, 3, 0],
+              [1, 0, 3, 4],
+              [0, 2, 3, 4],
+              [1, 2, 0, 4]]
+
+        t = Tensor.fromUncompressed(rank_ids=["K", "M"], root=a1)
+        a = t.getRoot()
+
+        Metrics.beginCollect("tmp/test_getPayloadRef_metrics_2D")
+        Metrics.trace("M", type_="A")
+        Metrics.registerRank("K")
+        Metrics.registerRank("M")
+
+        a.getPayloadRef(2, 1)
+        Metrics.incIter("K")
+        a.getPayloadRef(2, 3, trace="A")
+        Metrics.incIter("M")
+        a.getPayloadRef(1, 2, trace="A")
+
+        Metrics.endCollect()
+
+        corr = [
+            "K_pos,M_pos,K,M,fiber_pos\n",
+            "1,0,2,3,2\n",
+            "1,1,1,2,1\n"
+        ]
+
+        with open("tmp/test_getPayloadRef_metrics_2D-M-A.csv", "r") as f:
+            self.assertEqual(f.readlines(), corr)
 
     def test_getPayload_2(self):
         """Access payloads - multilevel"""

--- a/test/test_fiber_mutator.py
+++ b/test/test_fiber_mutator.py
@@ -24,6 +24,14 @@ class TestFiberMutator(unittest.TestCase):
         with self.assertRaises(AssertionError):
             a.swapRanks()
 
+    def test_swapRanks_preserves_default(self):
+        a = Fiber.fromYAMLfile("./data/test_fiber-2.yaml")
+        for _, f in a:
+            f.getRankAttrs().setDefault(float("inf"))
+
+        b = a.swapRanks()
+        self.assertEqual(b[0].payload.getDefault(), float("inf"))
+
     def test_split_uniform_below(self):
         """Test splitUniformBelow"""
 

--- a/test/test_fiber_split.py
+++ b/test/test_fiber_split.py
@@ -172,6 +172,20 @@ class TestFiberSplit(unittest.TestCase):
         #
         self.assertEqual(split.flattenRanks(style="relative"), f)
 
+    def test_split_uniform_preserves_default(self):
+        """Split uniform preserves default"""
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41]
+        p = [1, 10, 20, 100, 120, 310, 410 ]
+
+        f = Fiber(c,p, default=float("inf"))
+        split = f.splitUniform(10)
+
+        self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
+
+
     def test_split_uniform_halo(self):
         """splitUniform with halo"""
         # Original Fiber
@@ -629,6 +643,19 @@ class TestFiberSplit(unittest.TestCase):
         with self.assertRaises(AssertionError):
             f.splitNonUniform(splits)
 
+    def test_split_nonuniform_preserves_default(self):
+        """Split non-uniform preserves default"""
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41]
+        p = [1, 10, 20, 100, 120, 310, 410 ]
+
+        f = Fiber(c,p, default=float("inf"))
+        split = f.splitNonUniform([0, 11, 20])
+
+        self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
+
     def test_split_nonuniform_halo(self):
         """Test splitNonUniform with a halo"""
 
@@ -1051,6 +1078,19 @@ class TestFiberSplit(unittest.TestCase):
 
         self.assertEqual(split, corr)
 
+    def test_split_equal_preserves_default(self):
+        """Split equal preserves default"""
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41]
+        p = [1, 10, 20, 100, 120, 310, 410 ]
+
+        f = Fiber(c,p, default=float("inf"))
+        split = f.splitEqual(5)
+
+        self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
+
     def test_split_equal_halo(self):
         """splitEqual with halo"""
         # Original Fiber
@@ -1354,6 +1394,20 @@ class TestFiberSplit(unittest.TestCase):
         # Check the split
         #
         self.assertEqual(split, ans)
+
+    def test_split_unequal_preserves_default(self):
+        """Split un-equal preserves default"""
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41]
+        p = [1, 10, 20, 100, 120, 310, 410 ]
+
+        f = Fiber(c,p, default=float("inf"))
+        split = f.splitUnEqual([3, 4, 6])
+
+        self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
+
 
 
     def test_split_unequal_halo(self):

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -149,6 +149,12 @@ class TestFormat(unittest.TestCase):
         self.assertEqual(f.getFHBits("M"), 32)
         self.assertEqual(f.getFHBits("K"), 0)
 
+    def test_get_format(self):
+        """Test getFormat"""
+        f = Format(self.t, self.spec)
+        self.assertEqual(f.getFormat("M"), "U")
+        self.assertEqual(f.getFormat("K"), "C")
+
     def test_get_pbits(self):
         """Test getPBits"""
         f = Format(self.t, self.spec)

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -56,7 +56,7 @@ class TestPayload(unittest.TestCase):
         self.assertEqual(Metrics.dump(), {
             "Compute": {"payload_add": 4, "payload_update": 1}})
 
-        # Skip += 0
+        # Skip 0 += ...
         z = Payload(0)
         z += a
         self.assertEqual(Metrics.dump(), {"Compute": {"payload_add": 4, "payload_update": 2}})

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -56,6 +56,11 @@ class TestPayload(unittest.TestCase):
         self.assertEqual(Metrics.dump(), {
             "Compute": {"payload_add": 4, "payload_update": 1}})
 
+        # Skip += 0
+        z = Payload(0)
+        z += a
+        self.assertEqual(Metrics.dump(), {"Compute": {"payload_add": 4, "payload_update": 2}})
+
         Metrics.endCollect()
 
     def test_minus(self):

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -122,6 +122,20 @@ class TestPayload(unittest.TestCase):
 
         Metrics.endCollect()
 
+    def test_ilshift_metrics(self):
+        a = Payload(1)
+
+        Metrics.beginCollect()
+        a <<= 5
+        self.assertEqual(Metrics.dump(), {"Compute": {"payload_update": 1}})
+
+        a <<= 4
+        self.assertEqual(Metrics.dump(), {"Compute": {"payload_update": 2}})
+
+        a <<= 6
+        self.assertEqual(Metrics.dump(), {"Compute": {"payload_update": 3}})
+        Metrics.endCollect()
+
     def test_equality(self):
         cv = 8
         dv = 8

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -225,6 +225,17 @@ class TestTensor(unittest.TestCase):
 
         self.assertEqual(tensor, tensor_ref)
 
+    def test_fromFiber_non_zero_default(self):
+        """Test the construction of a tensor from a fiber includes correct
+        propagation of defaults"""
+
+        tensor_ref = Tensor.fromYAMLfile("./data/test_tensor-1.yaml")
+
+        root = tensor_ref.getRoot()
+
+        tensor = Tensor.fromFiber(["M", "K"], root, default=float("inf"))
+        self.assertEqual(tensor.getPayload(1, 0), 100)
+        self.assertEqual(tensor.getPayload(1, 3), float("inf"))
 
     def test_fromRandom(self):
         """Test construction of a random tensor"""

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -94,6 +94,20 @@ class TestTensorTransform(unittest.TestCase):
                 self.assertEqual(a_out.getRankIds(), ["M", "N", "K.1", "K.0"])
                 self.assertEqual(a_out.getShape(), [41, 42, 10, 10])
 
+    def test_split_uniform_preserves_default(self):
+        """Split uniform preserves default"""
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41]
+        p = [1, 10, 20, 100, 120, 310, 410 ]
+
+        f = Fiber(c,p, default=float("inf"))
+        t = Tensor.fromFiber(rank_ids=["M"], fiber=f, default=float("inf"))
+        split = t.splitUniform(10)
+
+        self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
+
     def test_splitNonUniform_0(self):
         """ Test splitNonUniform - depth=0 """
 
@@ -146,6 +160,21 @@ class TestTensorTransform(unittest.TestCase):
                 self.assertEqual(a_out, a_verify)
                 self.assertEqual(a_out.getRankIds(), ["M", "N", "K.1", "K.0"])
                 self.assertEqual(a_out.getShape(), [41, 42, 10, 10])
+
+    def test_split_nonuniform_preserves_default(self):
+        """Split non-uniform preserves default"""
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41]
+        p = [1, 10, 20, 100, 120, 310, 410 ]
+
+        f = Fiber(c,p, default=float("inf"))
+        t = Tensor.fromFiber(rank_ids=["M"], fiber=f, default=float("inf"))
+        split = t.splitNonUniform([0, 11, 20])
+
+        self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
+
 
     def test_floordiv(self):
         """ Test /, the __floordiv__ operator """
@@ -211,6 +240,21 @@ class TestTensorTransform(unittest.TestCase):
                 self.assertEqual(a_out.getRankIds(), ["M", "N", "K.1", "K.0"])
                 self.assertEqual(a_out.getShape(), [41, 42, 10, 10])
 
+    def test_split_equal_preserves_default(self):
+        """Split equal preserves default"""
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41]
+        p = [1, 10, 20, 100, 120, 310, 410 ]
+
+        f = Fiber(c,p, default=float("inf"))
+        t = Tensor.fromFiber(rank_ids=["M"], fiber=f, default=float("inf"))
+        split = t.splitEqual(5)
+
+        self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
+
+
     def test_splitUnEqual_0(self):
         """ Test splitUnEqual - depth=0 """
 
@@ -265,6 +309,19 @@ class TestTensorTransform(unittest.TestCase):
                 self.assertEqual(a_out.getRankIds(), ["M", "N", "K.1", "K.0"])
                 self.assertEqual(a_out.getShape(), [41, 42, 10, 10])
 
+    def test_split_unequal_preserves_default(self):
+        """Split un-equal preserves default"""
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41]
+        p = [1, 10, 20, 100, 120, 310, 410 ]
+
+        f = Fiber(c,p, default=float("inf"))
+        t = Tensor.fromFiber(rank_ids=["M"], fiber=f, default=float("inf"))
+        split = t.splitUnEqual([3, 4, 5])
+
+        self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
 
     def test_swapRanks_0(self):
         """ Test swapRanks - depth=0 """

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -348,6 +348,15 @@ class TestTensorTransform(unittest.TestCase):
         self.assertEqual(a_out.getRankIds(), ["M", "K", "N"])
         self.assertEqual(a_out.getShape(), [41, 10, 42])
 
+    def test_swapRanks_preserves_default(self):
+        """Test swapRanks preserves default"""
+        a = Tensor.fromYAMLfile("./data/tensor_transform-a.yaml")
+        a.setDefault(float("inf"))
+
+        a_out = a.swapRanks()
+
+        self.assertEqual(a_out.getDefault(), float("inf"))
+
 
     def test_swizzleRanks(self):
         """ Test swizzleRanks """
@@ -409,6 +418,21 @@ class TestTensorTransform(unittest.TestCase):
                                 [4, 0, 0, 5, 1, 3]])
         new_A_MK = A_MK.swizzleRanks(["M", "K"])
         self.assertEqual(A_MK, new_A_MK)
+
+    def test_swizzleRanks_same(self):
+        """Test swizzleRanks does nothing"""
+        A_MK = Tensor.fromUncompressed(["M", "K"],
+                               [[0, 0, 4, 0, 0, 5],
+                                [3, 2, 0, 3, 0, 2],
+                                [0, 2, 0, 0, 1, 2],
+                                [0, 0, 0, 0, 0, 0],
+                                [2, 5, 0, 0, 0, 5],
+                                [4, 1, 0, 0, 0, 0],
+                                [5, 0, 0, 1, 0, 0],
+                                [4, 0, 0, 5, 1, 3]])
+        A_MK.setDefault(float("inf"))
+        A_KM = A_MK.swizzleRanks(["K", "M"])
+        self.assertEqual(A_KM.getDefault(), float("inf"))
 
 
     def test_flattenRanks_0(self):

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -505,6 +505,23 @@ class TestTensorTransform(unittest.TestCase):
 
         self.assertEqual(f4, t0)
 
+    def test_flattenRanks_preserves_default(self):
+        """Test flattenRanks - levels=3, coord_style=absolute"""
+        t0 = Tensor.fromUncompressed(rank_ids=["A"], root=list(range(16)))
+        t0.setDefault(float("inf"))
+        self.assertEqual(t0.getDefault(), float("inf"))
+
+        s1 = t0.splitUniform(8, depth=0)
+        s2 = s1.splitUniform(4, depth=1)
+        s3 = s2.splitUniform(2, depth=2)
+        self.assertEqual(s3.getDefault(), float("inf"))
+
+        f4 = s3.flattenRanks(levels=3, coord_style="absolute")
+        f4.setRankIds(["A"])
+
+        self.assertEqual(f4, t0)
+        self.assertEqual(f4.getDefault(), float("inf"))
+
     def test_merge(self):
         """Test that mergeRanks merges together fibers"""
         f = Fiber([0, 1, 4, 5],
@@ -597,6 +614,19 @@ class TestTensorTransform(unittest.TestCase):
 
         self.assertEqual(mt.getRoot(), corr)
         self.assertEqual(mt.getShape(), [10, 10])
+
+    def test_merge_preserves_default(self):
+        """Test that mergeRanks merges together fibers while preserving an explicit default"""
+        f = Fiber([0, 1, 4, 5],
+                  [Fiber([0, 1, 2], [1, 2, 3], shape=10, default=float("inf")),
+                   Fiber([1, 3, 4], [4, 5, 6], shape=10, default=float("inf")),
+                   Fiber([4, 7], [7, 8], shape=10, default=float("inf")),
+                   Fiber([5, 7], [9, 10], shape=10, default=float("inf"))],
+                  shape=10)
+        t = Tensor.fromFiber(rank_ids=["M", "N"], fiber=f, default=float("inf"))
+        mt = t.mergeRanks()
+
+        self.assertEqual(mt.getDefault(), float("inf"))
 
     def test_unflattenRanks_empty(self):
         t = Tensor(rank_ids=["X", "Y", "Z"])

--- a/test/test_traffic.py
+++ b/test/test_traffic.py
@@ -128,6 +128,41 @@ class TestTraffic(unittest.TestCase):
                     z_ref += a_val * b_val
         Metrics.endCollect()
 
+    def test_buildFiberTrace(self):
+        "Test buildFiberTrace"""
+        Traffic.buildFiberTrace(
+            "tmp/test_traffic_single_stage-N-populate_read_0.csv",
+            ["M", "N"],
+            "tmp/test_buildFiberTrace-test.csv")
+
+        corr = [
+            "M_pos,K_pos,N_pos,M,K,N,fiber_pos\n",
+            "0,7,0,0,7,0,0\n",
+            "1,5,2,1,5,2,0\n",
+            "2,6,0,2,6,0,0\n",
+            "3,2,2,3,2,6,0\n",
+            "4,6,0,4,6,0,0\n",
+            "5,6,2,5,6,2,0\n"
+        ]
+
+        with open("tmp/test_buildFiberTrace-test.csv", "r") as f:
+            self.assertEqual(f.readlines(), corr)
+
+    def test_buildFiberTrace_top(self):
+        "Test buildFiberTrace for the top-level fiber"""
+        Traffic.buildFiberTrace(
+            "tmp/test_traffic_single_stage-N-populate_read_0.csv",
+            ["M"],
+            "tmp/test_buildFiberTrace_top-test.csv")
+
+        corr = [
+            "M_pos,K_pos,N_pos,M,K,N,fiber_pos\n",
+            "0,7,0,0,7,0,0\n",
+        ]
+
+        with open("tmp/test_buildFiberTrace_top-test.csv", "r") as f:
+            self.assertEqual(f.readlines(), corr)
+
     def test_filterTrace_more_ranks(self):
         """Test filterTrace"""
         K = 8

--- a/test/test_traffic.py
+++ b/test/test_traffic.py
@@ -128,41 +128,6 @@ class TestTraffic(unittest.TestCase):
                     z_ref += a_val * b_val
         Metrics.endCollect()
 
-    def test_buildFiberTrace(self):
-        "Test buildFiberTrace"""
-        Traffic.buildFiberTrace(
-            "tmp/test_traffic_single_stage-N-populate_read_0.csv",
-            ["M", "N"],
-            "tmp/test_buildFiberTrace-test.csv")
-
-        corr = [
-            "M_pos,K_pos,N_pos,M,K,N,fiber_pos\n",
-            "0,7,0,0,7,0,0\n",
-            "1,5,2,1,5,2,0\n",
-            "2,6,0,2,6,0,0\n",
-            "3,2,2,3,2,6,0\n",
-            "4,6,0,4,6,0,0\n",
-            "5,6,2,5,6,2,0\n"
-        ]
-
-        with open("tmp/test_buildFiberTrace-test.csv", "r") as f:
-            self.assertEqual(f.readlines(), corr)
-
-    def test_buildFiberTrace_top(self):
-        "Test buildFiberTrace for the top-level fiber"""
-        Traffic.buildFiberTrace(
-            "tmp/test_traffic_single_stage-N-populate_read_0.csv",
-            ["M"],
-            "tmp/test_buildFiberTrace_top-test.csv")
-
-        corr = [
-            "M_pos,K_pos,N_pos,M,K,N,fiber_pos\n",
-            "0,7,0,0,7,0,0\n",
-        ]
-
-        with open("tmp/test_buildFiberTrace_top-test.csv", "r") as f:
-            self.assertEqual(f.readlines(), corr)
-
     def test_filterTrace_more_ranks(self):
         """Test filterTrace"""
         K = 8

--- a/test/test_traffic.py
+++ b/test/test_traffic.py
@@ -231,17 +231,14 @@ class TestTraffic(unittest.TestCase):
 
     def test_buildPoint(self):
         """Build a point in the format-specific tensor"""
-        point = Traffic._buildPoint("1,2,3,4,5,False".split(","), [False, True], 1, "C")
+        point = Traffic._buildPoint("1,2,3,4,5,False".split(","), [False, True], 1)
         self.assertEqual(point, ("5",))
 
-        point = Traffic._buildPoint("1,2,3,4,5,False".split(","), [True, True], 1, "C")
+        point = Traffic._buildPoint("1,2,3,4,5,False".split(","), [True, True], 1)
         self.assertEqual(point, ("3", "5"))
 
-        point = Traffic._buildPoint("1,2,3,4,1,False".split(","), [True, True], 2, "C")
+        point = Traffic._buildPoint("1,2,3,4,1,False".split(","), [True, True], 2)
         self.assertEqual(point, ("3", "0"))
-
-        point = Traffic._buildPoint("1,2,3,4,1,False".split(","), [True, True], 2, "U")
-        self.assertEqual(point, ("3", "4"))
 
     def test_buildNextUseTrace(self):
         """Build a trace for each use that includes when the next use is"""
@@ -249,7 +246,7 @@ class TestTraffic(unittest.TestCase):
             read_fn="tmp/test_traffic_single_stage-N-populate_1.csv",
             comb_fn="tmp/test_buildNextUseTrace-comb.csv")
 
-        Traffic._buildNextUseTrace(["K", "N"], 2, "C",
+        Traffic._buildNextUseTrace(["K", "N"], 2,
             "tmp/test_buildNextUseTrace-comb.csv",
             "tmp/test_buildNextUseTrace_next_uses.csv")
 
@@ -434,38 +431,6 @@ class TestTraffic(unittest.TestCase):
         self.assertEqual(bits, {"F": {"read": 3 * 64}})
         self.assertEqual(overflows, 0)
 
-    def test_buffetTraffic_format(self):
-        """Test buffetTraffic obeys format"""
-        format_yaml = yaml.safe_load("""
-            K:
-                format: C
-                pbits: 32
-        """)
-        formats = {"C": Format(Tensor(rank_ids=["K"]), format_yaml)}
-
-        bindings = yaml.safe_load("""
-        - tensor: C
-          rank: K
-          type: payload
-          evict-on: M
-        """)
-        traces = {("C", "K", "payload", "read"): "tmp/test_traffic_stage0-K-intersect_2.csv"}
-
-        bits, overflows = Traffic.buffetTraffic(bindings, formats, traces, 8 * 32, 4 * 32)
-        self.assertEqual(bits, {"C": {"read": 6 * 4 * 32}})
-        self.assertEqual(overflows, 0)
-
-        format_yaml = yaml.safe_load("""
-            K:
-                format: U
-                pbits: 32
-        """)
-        formats = {"C": Format(Tensor(rank_ids=["K"]), format_yaml)}
-
-        bits, overflows = Traffic.buffetTraffic(bindings, formats, traces, 8 * 32, 4 * 32)
-        self.assertEqual(bits, {"C": {"read": 6 * 2 * 4 * 32}})
-        self.assertEqual(overflows, 0)
-
     def test_cacheTraffic_basic(self):
         """Test cacheTraffic"""
         bindings = yaml.safe_load("""
@@ -574,35 +539,4 @@ class TestTraffic(unittest.TestCase):
         self.assertEqual(bits, {"Z": {"read": 4224, "write": 7040}})
         self.assertEqual(overflows, 4)
 
-
-    def test_cacheTraffic_format(self):
-        """Test cacheTraffic obeys format"""
-        format_yaml = yaml.safe_load("""
-            K:
-                format: C
-                pbits: 32
-        """)
-        formats = {"C": Format(Tensor(rank_ids=["K"]), format_yaml)}
-
-        bindings = yaml.safe_load("""
-        - tensor: C
-          rank: K
-          type: payload
-        """)
-        traces = {("C", "K", "payload", "read"): "tmp/test_traffic_stage0-K-intersect_2.csv"}
-
-        bits, overflows = Traffic.cacheTraffic(bindings, formats, traces, 8 * 32, 4 * 32)
-        self.assertEqual(bits, {"C": {"read": 4 * 32}})
-        self.assertEqual(overflows, 0)
-
-        format_yaml = yaml.safe_load("""
-            K:
-                format: U
-                pbits: 32
-        """)
-        formats = {"C": Format(Tensor(rank_ids=["K"]), format_yaml)}
-
-        bits, overflows = Traffic.cacheTraffic(bindings, formats, traces, 8 * 32, 4 * 32)
-        self.assertEqual(bits, {"C": {"read": 2 * 4 * 32}})
-        self.assertEqual(overflows, 0)
 

--- a/test/test_traffic.py
+++ b/test/test_traffic.py
@@ -229,6 +229,19 @@ class TestTraffic(unittest.TestCase):
             open("test_traffic-test_combineTraces_both-corr.csv", "r") as f_corr:
             self.assertEqual(f_test.readlines(), f_corr.readlines())
 
+    def test_buildPoint(self):
+        """Build a point in the format-specific tensor"""
+        point = Traffic._buildPoint("1,2,3,4,5,False".split(","), [False, True], 1, "C")
+        self.assertEqual(point, ("5",))
+
+        point = Traffic._buildPoint("1,2,3,4,5,False".split(","), [True, True], 1, "C")
+        self.assertEqual(point, ("3", "5"))
+
+        point = Traffic._buildPoint("1,2,3,4,1,False".split(","), [True, True], 2, "C")
+        self.assertEqual(point, ("3", "0"))
+
+        point = Traffic._buildPoint("1,2,3,4,1,False".split(","), [True, True], 2, "U")
+        self.assertEqual(point, ("3", "4"))
 
     def test_buildNextUseTrace(self):
         """Build a trace for each use that includes when the next use is"""
@@ -236,7 +249,7 @@ class TestTraffic(unittest.TestCase):
             read_fn="tmp/test_traffic_single_stage-N-populate_1.csv",
             comb_fn="tmp/test_buildNextUseTrace-comb.csv")
 
-        Traffic._buildNextUseTrace(["K", "N"], 2,
+        Traffic._buildNextUseTrace(["K", "N"], 2, "C",
             "tmp/test_buildNextUseTrace-comb.csv",
             "tmp/test_buildNextUseTrace_next_uses.csv")
 
@@ -421,6 +434,38 @@ class TestTraffic(unittest.TestCase):
         self.assertEqual(bits, {"F": {"read": 3 * 64}})
         self.assertEqual(overflows, 0)
 
+    def test_buffetTraffic_format(self):
+        """Test buffetTraffic obeys format"""
+        format_yaml = yaml.safe_load("""
+            K:
+                format: C
+                pbits: 32
+        """)
+        formats = {"C": Format(Tensor(rank_ids=["K"]), format_yaml)}
+
+        bindings = yaml.safe_load("""
+        - tensor: C
+          rank: K
+          type: payload
+          evict-on: M
+        """)
+        traces = {("C", "K", "payload", "read"): "tmp/test_traffic_stage0-K-intersect_2.csv"}
+
+        bits, overflows = Traffic.buffetTraffic(bindings, formats, traces, 8 * 32, 4 * 32)
+        self.assertEqual(bits, {"C": {"read": 6 * 4 * 32}})
+        self.assertEqual(overflows, 0)
+
+        format_yaml = yaml.safe_load("""
+            K:
+                format: U
+                pbits: 32
+        """)
+        formats = {"C": Format(Tensor(rank_ids=["K"]), format_yaml)}
+
+        bits, overflows = Traffic.buffetTraffic(bindings, formats, traces, 8 * 32, 4 * 32)
+        self.assertEqual(bits, {"C": {"read": 6 * 2 * 4 * 32}})
+        self.assertEqual(overflows, 0)
+
     def test_cacheTraffic_basic(self):
         """Test cacheTraffic"""
         bindings = yaml.safe_load("""
@@ -529,4 +574,35 @@ class TestTraffic(unittest.TestCase):
         self.assertEqual(bits, {"Z": {"read": 4224, "write": 7040}})
         self.assertEqual(overflows, 4)
 
+
+    def test_cacheTraffic_format(self):
+        """Test cacheTraffic obeys format"""
+        format_yaml = yaml.safe_load("""
+            K:
+                format: C
+                pbits: 32
+        """)
+        formats = {"C": Format(Tensor(rank_ids=["K"]), format_yaml)}
+
+        bindings = yaml.safe_load("""
+        - tensor: C
+          rank: K
+          type: payload
+        """)
+        traces = {("C", "K", "payload", "read"): "tmp/test_traffic_stage0-K-intersect_2.csv"}
+
+        bits, overflows = Traffic.cacheTraffic(bindings, formats, traces, 8 * 32, 4 * 32)
+        self.assertEqual(bits, {"C": {"read": 4 * 32}})
+        self.assertEqual(overflows, 0)
+
+        format_yaml = yaml.safe_load("""
+            K:
+                format: U
+                pbits: 32
+        """)
+        formats = {"C": Format(Tensor(rank_ids=["K"]), format_yaml)}
+
+        bits, overflows = Traffic.cacheTraffic(bindings, formats, traces, 8 * 32, 4 * 32)
+        self.assertEqual(bits, {"C": {"read": 2 * 4 * 32}})
+        self.assertEqual(overflows, 0)
 


### PR DESCRIPTION
This pull request covers two sets of improvements. First, it improves the metrics counting in two ways:
1. More functions, such as union (`__or__`), `getPayload`, and `getPayloadRef` can produce traces of accesses.
2. The metrics counted distinguish between addition with 0 and addition between two non-zeros. An effectual add is only counted if both operands are non-zero.

Second, it improves support for non-zero defaults, including allowing them to be propagated through transformations like partitioning, flattening, and swizzling