### PR TITLE
Support halos before and after the active range of a partition

### DIFF
--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -3238,6 +3238,7 @@ class Fiber:
 
         assert not self.isLazy()
         assert isinstance(step, int) and isinstance(pre_halo, int) and isinstance(post_halo, int)
+        assert pre_halo >= 0 and post_halo >= 0
 
         class _SplitterUniform():
 
@@ -3366,7 +3367,9 @@ class Fiber:
         if isinstance(splits, Fiber):
             splits = splits.getCoords()
 
-        assert isinstance(post_halo, int) and all(isinstance(split, int) for split in splits)
+        assert all(isinstance(split, int) for split in splits)
+        assert isinstance(pre_halo, int) and isinstance(post_halo, int)
+        assert pre_halo >= 0 and post_halo >= 0
 
         class _SplitterNonUniform():
 
@@ -3545,8 +3548,9 @@ class Fiber:
 
         """
         assert not self.isLazy()
-        assert isinstance(post_halo, int)
         assert isinstance(step, int)
+        assert isinstance(pre_halo, int) and isinstance(post_halo, int)
+        assert pre_halo >= 0 and post_halo >= 0
 
         class _SplitterEqual():
 
@@ -3615,8 +3619,9 @@ class Fiber:
 
         """
         assert not self.isLazy()
-        assert isinstance(post_halo, int)
         assert all(isinstance(size, numbers.Number) for size in sizes)
+        assert isinstance(pre_halo, int) and isinstance(post_halo, int)
+        assert pre_halo >= 0 and post_halo >= 0
 
         class _SplitterUnEqual():
 

--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -3234,7 +3234,6 @@ class Fiber:
 
         assert not self.isLazy()
         assert isinstance(halo, int) and isinstance(step, int)
-        assert halo <= step
 
         class _SplitterUniform():
 
@@ -3383,7 +3382,6 @@ class Fiber:
             splits = splits.getCoords()
 
         assert isinstance(halo, int) and all(isinstance(split, int) for split in splits)
-        assert len(splits) < 2 or halo <= min(splits[i + 1] - splits[i] for i in range(len(splits) - 1))
 
         class _SplitterNonUniform():
 
@@ -3540,7 +3538,6 @@ class Fiber:
         assert not self.isLazy()
         assert isinstance(halo, int)
         assert isinstance(step, int)
-        assert halo <= step
 
         class _SplitterEqual():
 
@@ -3679,7 +3676,6 @@ class Fiber:
         assert not self.isLazy()
         assert isinstance(halo, int)
         assert all(isinstance(size, numbers.Number) for size in sizes)
-        assert halo <= min(sizes)
 
         class _SplitterUnEqual():
 

--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -3263,23 +3263,30 @@ class Fiber:
                 search_start = 0
 
                 for c, p in self.fiber:
+                    # If the coordinate will not be in any partition, skip it
                     if c < active_start - self.pre_halo:
                         continue
 
                     if c >= active_end + self.post_halo:
                         break
 
+                    # Start at the partition where the coordinate will be in
+                    # the post-halo
                     part = (c - self.post_halo) // self.step * self.step
+                    # End at the partition where the coordinate will be in the
+                    # pre-halo
                     part_end = (c + self.pre_halo) // self.step * self.step + self.step
 
                     inds = []
                     while part < part_end:
+                        # Ensure that this partition is within the active range
                         if part + self.step <= active_start:
                             part += self.step
                             continue
                         elif part >= active_end:
                             break
 
+                        # Add the coordinate to the partition
                         if part in upper_coords[search_start:]:
                             i = upper_coords.index(part)
                         else:

--- a/test/data/tensor_transform-a-splitEqual_0.yaml
+++ b/test/data/tensor_transform-a-splitEqual_0.yaml
@@ -9,7 +9,7 @@ tensor:
   root:
   - fiber:
       coords:
-      - 10
+      - 0
       - 40
       payloads:
       - fiber:

--- a/test/data/tensor_transform-a-splitEqual_1.yaml
+++ b/test/data/tensor_transform-a-splitEqual_1.yaml
@@ -15,7 +15,7 @@ tensor:
       payloads:
       - fiber:
           coords:
-          - 11
+          - 0
           payloads:
           - fiber:
               coords:
@@ -30,7 +30,7 @@ tensor:
                   - 70
       - fiber:
           coords:
-          - 12
+          - 0
           payloads:
           - fiber:
               coords:
@@ -59,7 +59,7 @@ tensor:
                   - 50
       - fiber:
           coords:
-          - 11
+          - 0
           - 33
           payloads:
           - fiber:

--- a/test/data/tensor_transform-a-splitEqual_2.yaml
+++ b/test/data/tensor_transform-a-splitEqual_2.yaml
@@ -19,7 +19,7 @@ tensor:
           payloads:
           - fiber:
               coords:
-              - 6
+              - 0
               payloads:
               - fiber:
                   coords:
@@ -35,7 +35,7 @@ tensor:
           payloads:
           - fiber:
               coords:
-              - 1
+              - 0
               - 3
               payloads:
               - fiber:
@@ -54,7 +54,7 @@ tensor:
                   - 40
           - fiber:
               coords:
-              - 3
+              - 0
               - 5
               payloads:
               - fiber:
@@ -78,7 +78,7 @@ tensor:
           payloads:
           - fiber:
               coords:
-              - 1
+              - 0
               - 6
               - 9
               payloads:
@@ -112,7 +112,7 @@ tensor:
                   - 1
           - fiber:
               coords:
-              - 3
+              - 0
               - 5
               payloads:
               - fiber:
@@ -129,7 +129,7 @@ tensor:
                   - 50
           - fiber:
               coords:
-              - 1
+              - 0
               payloads:
               - fiber:
                   coords:

--- a/test/data/tensor_transform-a-splitUnEqual_0.yaml
+++ b/test/data/tensor_transform-a-splitUnEqual_0.yaml
@@ -9,7 +9,7 @@ tensor:
   root:
   - fiber:
       coords:
-      - 10
+      - 0
       - 40
       payloads:
       - fiber:

--- a/test/data/tensor_transform-a-splitUnEqual_1.yaml
+++ b/test/data/tensor_transform-a-splitUnEqual_1.yaml
@@ -15,7 +15,7 @@ tensor:
       payloads:
       - fiber:
           coords:
-          - 11
+          - 0
           payloads:
           - fiber:
               coords:
@@ -30,7 +30,7 @@ tensor:
                   - 70
       - fiber:
           coords:
-          - 12
+          - 0
           payloads:
           - fiber:
               coords:
@@ -59,7 +59,7 @@ tensor:
                   - 50
       - fiber:
           coords:
-          - 11
+          - 0
           - 33
           - 41
           payloads:

--- a/test/data/tensor_transform-a-splitUnEqual_2.yaml
+++ b/test/data/tensor_transform-a-splitUnEqual_2.yaml
@@ -19,7 +19,7 @@ tensor:
           payloads:
           - fiber:
               coords:
-              - 6
+              - 0
               payloads:
               - fiber:
                   coords:
@@ -35,7 +35,7 @@ tensor:
           payloads:
           - fiber:
               coords:
-              - 1
+              - 0
               - 3
               - 8
               payloads:
@@ -58,7 +58,7 @@ tensor:
                   - 40
           - fiber:
               coords:
-              - 3
+              - 0
               - 5
               payloads:
               - fiber:
@@ -82,7 +82,7 @@ tensor:
           payloads:
           - fiber:
               coords:
-              - 1
+              - 0
               - 6
               - 8
               payloads:
@@ -116,7 +116,7 @@ tensor:
                   - 1
           - fiber:
               coords:
-              - 3
+              - 0
               - 5
               payloads:
               - fiber:
@@ -133,7 +133,7 @@ tensor:
                   - 50
           - fiber:
               coords:
-              - 1
+              - 0
               payloads:
               - fiber:
                   coords:

--- a/test/test_fiber_infix_split.py
+++ b/test/test_fiber_infix_split.py
@@ -79,13 +79,13 @@ class TestFiberInfixSplit(unittest.TestCase):
 
         self.ans = {}
 
-        self.ans[2] = Fiber([3, 30],
+        self.ans[2] = Fiber([0, 30],
                             [Fiber([3, 6, 8, 9, 12, 16, 19, 20, 28],
                                    [8, 9, 6, 3, 5, 4, 1, 4, 6]),
                              Fiber([30, 32, 38, 40, 43, 46, 47, 48, 49],
                                    [4, 1, 6, 2, 6, 5, 9, 2, 5])])
 
-        self.ans[3] = Fiber([3, 19, 40],
+        self.ans[3] = Fiber([0, 19, 40],
                             [Fiber([3, 6, 8, 9, 12, 16],
                                    [8, 9, 6, 3, 5, 4]),
                              Fiber([19, 20, 28, 30, 32, 38],
@@ -93,7 +93,7 @@ class TestFiberInfixSplit(unittest.TestCase):
                              Fiber([40, 43, 46, 47, 48, 49],
                                    [2, 6, 5, 9, 2, 5])])
 
-        self.ans[4] = Fiber([3, 16, 32, 47],
+        self.ans[4] = Fiber([0, 16, 32, 47],
                             [Fiber([3, 6, 8, 9, 12],
                                    [8, 9, 6, 3, 5]),
                              Fiber([16, 19, 20, 28, 30],
@@ -103,7 +103,7 @@ class TestFiberInfixSplit(unittest.TestCase):
                              Fiber([47, 48, 49],
                                    [9, 2, 5])])
 
-        self.ans[5] = Fiber([3, 12, 28, 40, 48],
+        self.ans[5] = Fiber([0, 12, 28, 40, 48],
                             [Fiber([3, 6, 8, 9],
                                    [8, 9, 6, 3]),
                              Fiber([12, 16, 19, 20],

--- a/test/test_fiber_split.py
+++ b/test/test_fiber_split.py
@@ -186,8 +186,8 @@ class TestFiberSplit(unittest.TestCase):
         self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
 
 
-    def test_split_uniform_halo(self):
-        """splitUniform with halo"""
+    def test_split_uniform_post_halo(self):
+        """splitUniform with post_halo"""
         # Original Fiber
         c = [8, 9, 12, 15, 17, 32]
         p = [3, 4,  5,  6,  7,  8]
@@ -221,7 +221,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         coords = 8
-        split = f.splitUniform(coords, halo=2)
+        split = f.splitUniform(coords, post_halo=2)
 
         #
         # Check the split
@@ -232,8 +232,8 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref_payloads[i])
             self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
 
-    def test_split_uniform_halo_active_only(self):
-        """splitUniform with halo, only active coordinates appear as non-halo elements"""
+    def test_split_uniform_post_halo_active_only(self):
+        """splitUniform with post_halo, only active coordinates appear as non-post_halo elements"""
         # Original Fiber
         c = [0, 9, 12, 15, 17, 18]
         p = [3, 4,  5,  6,  7,  8]
@@ -261,7 +261,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         coords = 4
-        split = f.splitUniform(coords, halo=2)
+        split = f.splitUniform(coords, post_halo=2)
 
         #
         # Check the split
@@ -272,8 +272,8 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref_payloads[i])
             self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
 
-    def test_split_uniform_halo_prev_active_halo(self):
-        """splitUniform with halo, inactive coordinates can be haloed even if
+    def test_split_uniform_post_halo_prev_active_post_halo(self):
+        """splitUniform with post_halo, inactive coordinates can be post_haloed even if
         they should have been inside the active part of a partition"""
         # Original Fiber
         c = [0, 9, 12, 14, 17, 18, 20]
@@ -304,7 +304,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         coords = 5
-        split = f.splitUniform(coords, halo=3)
+        split = f.splitUniform(coords, post_halo=3)
 
         #
         # Check the split
@@ -315,8 +315,8 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref_payloads[i])
             self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
 
-    def test_split_uniform_build_halo_once(self):
-        """splitUniform, make sure that if the halo for the last partition has already
+    def test_split_uniform_build_post_halo_once(self):
+        """splitUniform, make sure that if the post_halo for the last partition has already
         been built, we do not try to build it again"""
         c = [0, 9, 12, 14, 17, 19, 20]
         p = [3, 4,  5,  6,  7,  8, 9]
@@ -344,7 +344,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         coords = 10
-        split = f.splitUniform(coords, halo=3)
+        split = f.splitUniform(coords, post_halo=3)
 
         #
         # Check the split
@@ -646,8 +646,8 @@ class TestFiberSplit(unittest.TestCase):
 
         self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
 
-    def test_split_nonuniform_halo(self):
-        """Test splitNonUniform with a halo"""
+    def test_split_nonuniform_post_halo(self):
+        """Test splitNonUniform with a post_halo"""
 
         #
         # Create the fiber to be split
@@ -681,7 +681,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         splits = [8, 11, 15, 20, 30]
-        split = f.splitNonUniform(splits, halo=2)
+        split = f.splitNonUniform(splits, post_halo=2)
 
         #
         # Check the split
@@ -691,8 +691,8 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sc, ranges[i][0])
             self.assertEqual(sp, split_ref[i])
 
-    def test_split_nonuniform_halo_outside_active(self):
-        """Test splitNonUniform with a halo, allowing the halo to extend
+    def test_split_nonuniform_post_halo_outside_active(self):
+        """Test splitNonUniform with a post_halo, allowing the post_halo to extend
         outside the active_range"""
 
         #
@@ -726,7 +726,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         splits = [2, 8, 11, 20, 30, 40]
-        split = f.splitNonUniform(splits, halo=2)
+        split = f.splitNonUniform(splits, post_halo=2)
 
         #
         # Check the split
@@ -737,9 +737,9 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref[i])
             self.assertEqual(sp.getActive(), split_ref[i].getActive())
 
-    def test_split_nonuniform_halo_outside_active2(self):
-        """Test splitNonUniform with a halo, making normally active coordinates
-        halo coordinates"""
+    def test_split_nonuniform_post_halo_outside_active2(self):
+        """Test splitNonUniform with a post_halo, making normally active coordinates
+        post_halo coordinates"""
 
         #
         # Create the fiber to be split
@@ -771,7 +771,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         splits = [8, 11, 20, 40]
-        split = f.splitNonUniform(splits, halo=2)
+        split = f.splitNonUniform(splits, post_halo=2)
 
         #
         # Check the split
@@ -782,8 +782,8 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref[i])
             self.assertEqual(sp.getActive(), split_ref[i].getActive())
 
-    def test_split_nonuniform_halo_outside_active3(self):
-        """Test splitNonUniform with a halo, ensure that the halo is only
+    def test_split_nonuniform_post_halo_outside_active3(self):
+        """Test splitNonUniform with a post_halo, ensure that the post_halo is only
         built once"""
 
         #
@@ -818,7 +818,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         splits = [8, 11, 15, 20, 30, 50]
-        split = f.splitNonUniform(splits, halo=2)
+        split = f.splitNonUniform(splits, post_halo=2)
 
         #
         # Check the split
@@ -828,8 +828,8 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sc, ranges[i][0])
             self.assertEqual(sp, split_ref[i])
 
-    def test_split_nonuniform_valid_halo(self):
-        """Test that splitNonUniform only accepts valid halos"""
+    def test_split_nonuniform_valid_post_halo(self):
+        """Test that splitNonUniform only accepts valid post_halos"""
         #
         # Create the fiber to be split
         #
@@ -841,7 +841,7 @@ class TestFiberSplit(unittest.TestCase):
         splits = [8, 11, 30]
 
         with self.assertRaises(AssertionError):
-            f.splitNonUniform(splits, halo=(10, 29))
+            f.splitNonUniform(splits, post_halo=(10, 29))
 
     def test_split_nonuniform_then_flatten(self):
         """Test that flattenRanks can undo splitNonUniform"""
@@ -1032,8 +1032,8 @@ class TestFiberSplit(unittest.TestCase):
         #
         self.assertEqual(split, ans)
 
-    def test_split_equal_int_step_halo_only(self):
-        """Test that splitEqual only works on an integer step, integer halo, and no halo with tuple coordinates"""
+    def test_split_equal_int_step_post_halo_only(self):
+        """Test that splitEqual only works on an integer step, integer post_halo, and no post_halo with tuple coordinates"""
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [1, 10, 20, 100, 120, 310, 410 ]
 
@@ -1045,10 +1045,10 @@ class TestFiberSplit(unittest.TestCase):
             f.splitEqual((1, 2))
 
         with self.assertRaises(AssertionError):
-            f.splitEqual(5, halo=(1, 2))
+            f.splitEqual(5, post_halo=(1, 2))
 
         with self.assertRaises(AssertionError):
-            f.splitEqual(5, halo=3)
+            f.splitEqual(5, post_halo=3)
 
     def test_split_equal_tuple_coords(self):
         """Test that splitEqual works with tuple coordinates"""
@@ -1078,8 +1078,8 @@ class TestFiberSplit(unittest.TestCase):
 
         self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
 
-    def test_split_equal_halo(self):
-        """splitEqual with halo"""
+    def test_split_equal_post_halo(self):
+        """splitEqual with post_halo"""
         # Original Fiber
         c = [0, 1, 8, 9, 12, 15, 17, 19]
         p = [1, 2, 3, 4,  5,  6,  7,  8]
@@ -1109,7 +1109,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         size = 3
-        split = f.splitEqual(size, halo=3)
+        split = f.splitEqual(size, post_halo=3)
 
         #
         # Check the split
@@ -1120,8 +1120,8 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref_payloads[i])
             self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
 
-    def test_split_equal_halo_active_only(self):
-        """splitEqual with halo"""
+    def test_split_equal_post_halo_active_only(self):
+        """splitEqual with post_halo"""
         # Original Fiber
         c = [0, 8, 9, 11, 12, 15, 17, 18, 25]
         p = [1, 2, 3, 4,  5,  6,  7,  8,  9 ]
@@ -1149,7 +1149,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         size = 3
-        split = f.splitEqual(size, halo=3)
+        split = f.splitEqual(size, post_halo=3)
 
         #
         # Check the split
@@ -1160,8 +1160,8 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref_payloads[i])
             self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
 
-    def test_split_equal_correct_final_halo(self):
-        """splitEqual - Correctly build the final halo"""
+    def test_split_equal_correct_final_post_halo(self):
+        """splitEqual - Correctly build the final post_halo"""
         c = list(range(40))
         p = list(range(40))
         p[0] = 100
@@ -1199,7 +1199,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         size = 5
-        split = f.splitEqual(size, halo=4)
+        split = f.splitEqual(size, post_halo=4)
 
         #
         # Check the split
@@ -1387,8 +1387,8 @@ class TestFiberSplit(unittest.TestCase):
 
 
 
-    def test_split_unequal_halo(self):
-        """Test splitUnequal - with halo (all parts are filled)"""
+    def test_split_unequal_post_halo(self):
+        """Test splitUnequal - with post_halo (all parts are filled)"""
 
         #
         # Create the fiber to be split
@@ -1420,7 +1420,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         sizes = [1, 2, 3]
-        split = f.splitUnEqual(sizes, halo=1)
+        split = f.splitUnEqual(sizes, post_halo=1)
 
         #
         # Check the split
@@ -1431,8 +1431,8 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref[i])
             self.assertEqual(sp.getActive(), split_ref[i].getActive())
 
-    def test_split_unequal_halo2(self):
-        """Test splitUnequal - With halo (last part does not finish) """
+    def test_split_unequal_post_halo2(self):
+        """Test splitUnequal - With post_halo (last part does not finish) """
 
         #
         # Create the fiber to be split
@@ -1464,7 +1464,7 @@ class TestFiberSplit(unittest.TestCase):
         # Do the split
         #
         sizes = [1, 2, 5, 16]
-        split = f.splitUnEqual(sizes, halo=1)
+        split = f.splitUnEqual(sizes, post_halo=1)
 
         #
         # Check the split
@@ -1485,19 +1485,19 @@ class TestFiberSplit(unittest.TestCase):
         f_flat = f_split.flattenRanks(style="tuple")
 
         with self.assertRaises(AssertionError):
-            f.splitUnEqual([3, 4, 5], halo=(2, 3))
+            f.splitUnEqual([3, 4, 5], post_halo=(2, 3))
 
         with self.assertRaises(AssertionError):
             f.splitUnEqual([3, 4, (5, 6)])
 
         with self.assertRaises(AssertionError):
-            f_flat.splitUnEqual([3, 4, 5], halo=(2, 3))
+            f_flat.splitUnEqual([3, 4, 5], post_halo=(2, 3))
 
         with self.assertRaises(AssertionError):
             f_split.splitUnEqual([3, 4, (5, 6)])
 
         with self.assertRaises(AssertionError):
-            f_flat.splitUnEqual([3, 4, 5], halo=2)
+            f_flat.splitUnEqual([3, 4, 5], post_halo=2)
 
     def test_split_unequal_then_flatten(self):
         """Test that flattenRanks can undo splitUnequal"""

--- a/test/test_fiber_split.py
+++ b/test/test_fiber_split.py
@@ -66,20 +66,32 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
 
 
-    def test_split_uniform_on_int_coords_only(self):
-        """Test that splitUnform works on integer coordinates only"""
+    def test_split_uniform_asserts(self):
+        """Test the splitUniform asserts"""
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [1, 10, 20, 100, 120, 310, 410 ]
 
         f = Fiber(c,p)
-        f = f.splitUniform(5)
-        f = f.flattenRanks(style="tuple")
+        split = f.splitUniform(5)
+        flattened = split.flattenRanks(style="tuple")
 
         with self.assertRaises(AssertionError):
-            f.splitUniform((1, 2))
+            flattened.splitUniform((1, 2))
 
         with self.assertRaises(AssertionError):
-            f.splitUniform(5)
+            flattened.splitUniform(5)
+
+        with self.assertRaises(AssertionError):
+            f.splitUniform(5, pre_halo=(1, 2))
+
+        with self.assertRaises(AssertionError):
+            f.splitUniform(5, post_halo=(1, 2))
+
+        with self.assertRaises(AssertionError):
+            f.splitUniform(5, pre_halo=-1)
+
+        with self.assertRaises(AssertionError):
+            f.splitUniform(5, post_halo=-1)
 
     def test_split_uniform_then_flatten(self):
         """Test that flattenRanks() can undo splitUniform"""
@@ -756,7 +768,7 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref[i])
             self.assertEqual(sp.getActive(), split_ref[i].getActive())
 
-    def test_split_non_uniform_int_splits(self):
+    def test_split_non_uniform_asserts(self):
         """Test splitNonUniform only works with integer splits"""
 
         #
@@ -771,6 +783,21 @@ class TestFiberSplit(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             f.splitNonUniform(splits)
+
+        splits = [8, 19, 40]
+
+        with self.assertRaises(AssertionError):
+            f.splitNonUniform(splits, pre_halo=(1, 2))
+
+        with self.assertRaises(AssertionError):
+            f.splitNonUniform(splits, post_halo=(1, 2))
+
+        with self.assertRaises(AssertionError):
+            f.splitNonUniform(splits, pre_halo=-1)
+
+        with self.assertRaises(AssertionError):
+            f.splitNonUniform(splits, post_halo=-1)
+
 
     def test_split_nonuniform_preserves_default(self):
         """Split non-uniform preserves default"""
@@ -1317,23 +1344,35 @@ class TestFiberSplit(unittest.TestCase):
         #
         self.assertEqual(split, ans)
 
-    def test_split_equal_int_step_post_halo_only(self):
+    def test_split_equal_asserts(self):
         """Test that splitEqual only works on an integer step, integer post_halo, and no post_halo with tuple coordinates"""
         c = [0, 1, 9, 10, 12, 31, 41]
         p = [1, 10, 20, 100, 120, 310, 410 ]
 
         f = Fiber(c,p)
-        f = f.splitUniform(5)
-        f = f.flattenRanks(style="tuple")
+        split = f.splitUniform(5)
+        flattened = split.flattenRanks(style="tuple")
 
         with self.assertRaises(AssertionError):
-            f.splitEqual((1, 2))
+            flattened.splitEqual((1, 2))
+
+        with self.assertRaises(AssertionError):
+            flattened.splitEqual(5, post_halo=(1, 2))
+
+        with self.assertRaises(AssertionError):
+            flattened.splitEqual(5, post_halo=3)
+
+        with self.assertRaises(AssertionError):
+            f.splitEqual(5, pre_halo=(1, 2))
 
         with self.assertRaises(AssertionError):
             f.splitEqual(5, post_halo=(1, 2))
 
         with self.assertRaises(AssertionError):
-            f.splitEqual(5, post_halo=3)
+            f.splitEqual(5, pre_halo=-1)
+
+        with self.assertRaises(AssertionError):
+            f.splitEqual(5, post_halo=-1)
 
     def test_split_equal_tuple_coords(self):
         """Test that splitEqual works with tuple coordinates"""
@@ -1993,6 +2032,18 @@ class TestFiberSplit(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             f_flat.splitUnEqual([3, 4, 5], post_halo=2)
+
+        with self.assertRaises(AssertionError):
+            f.splitUnEqual([3, 4, 5], pre_halo=(1, 2))
+
+        with self.assertRaises(AssertionError):
+            f.splitUnEqual([3, 4, 5], post_halo=(1, 2))
+
+        with self.assertRaises(AssertionError):
+            f.splitUnEqual([3, 4, 5], pre_halo=-1)
+
+        with self.assertRaises(AssertionError):
+            f.splitUnEqual([3, 4, 5], post_halo=-1)
 
     def test_split_unequal_then_flatten(self):
         """Test that flattenRanks can undo splitUnequal"""

--- a/test/test_fiber_split.py
+++ b/test/test_fiber_split.py
@@ -355,16 +355,6 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref_payloads[i])
             self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
 
-    def test_split_uniform_halo_not_bigger_than_step(self):
-        """splitUniform, halo cannot be bigger than the step"""
-        # Original Fiber
-        c = [8, 9, 12, 15, 17, 32]
-        p = [3, 4,  5,  6,  7,  8]
-        f = Fiber(c, p)
-
-        with self.assertRaises(AssertionError):
-            f.splitUniform(3, halo=5)
-
     def test_split_nonuniform_empty(self):
         """Test splitNonUniform on empty fiber"""
         empty = Fiber()
@@ -853,9 +843,6 @@ class TestFiberSplit(unittest.TestCase):
         with self.assertRaises(AssertionError):
             f.splitNonUniform(splits, halo=(10, 29))
 
-        with self.assertRaises(AssertionError):
-            f.splitNonUniform(splits, halo=100)
-
     def test_split_nonuniform_then_flatten(self):
         """Test that flattenRanks can undo splitNonUniform"""
 
@@ -1223,16 +1210,6 @@ class TestFiberSplit(unittest.TestCase):
             self.assertEqual(sp, split_ref_payloads[i])
             self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
 
-    def test_split_equal_halo_not_bigger_than_step(self):
-        """splitEqual, halo cannot be bigger than the step"""
-        # Original Fiber
-        c = [8, 9, 12, 15, 17, 32]
-        p = [3, 4,  5,  6,  7,  8]
-        f = Fiber(c, p)
-
-        with self.assertRaises(AssertionError):
-            f.splitEqual(3, halo=5)
-
     def test_split_equal_then_flatten(self):
         """Test that flattenRanks can undo splitEqual"""
 
@@ -1518,9 +1495,6 @@ class TestFiberSplit(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             f_split.splitUnEqual([3, 4, (5, 6)])
-
-        with self.assertRaises(AssertionError):
-            f.splitUnEqual([3, 4, 5], halo=4)
 
         with self.assertRaises(AssertionError):
             f_flat.splitUnEqual([3, 4, 5], halo=2)

--- a/test/test_fiber_split.py
+++ b/test/test_fiber_split.py
@@ -1796,6 +1796,48 @@ class TestFiberSplit(unittest.TestCase):
 
 
 
+    def test_split_unequal_pre_halo(self):
+        """Test splitUnequal - with pre_halo"""
+
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41, 51]
+        p = [1, 10, 20, 100, 120, 310, 410, 510 ]
+
+        f = Fiber(c,p, active_range=(1, 41))
+
+        #
+        # Create list of reference fibers after the split
+        #
+        css = [ [ 0, 1, 9 ],
+                [ 9, 10, 12, 31 ] ]
+
+        pss = [ [ 1, 10, 20 ],
+                [ 20, 100, 120, 310 ] ]
+
+        ranges = [(1, 10), (10, 41)]
+
+        split_ref = []
+
+        for cs, ps, range_ in zip(css, pss, ranges):
+            split_ref.append(Fiber(cs, ps, active_range=range_))
+
+        #
+        # Do the split
+        #
+        sizes = [2, 3]
+        split = f.splitUnEqual(sizes, pre_halo=1)
+
+        #
+        # Check the split
+        #
+        self.assertEqual(len(split), len(css))
+        for i, (sc, sp)  in enumerate(split):
+            self.assertEqual(sc, ranges[i][0])
+            self.assertEqual(sp, split_ref[i])
+            self.assertEqual(sp.getActive(), split_ref[i].getActive())
+
     def test_split_unequal_post_halo(self):
         """Test splitUnequal - with post_halo (all parts are filled)"""
 
@@ -1836,7 +1878,51 @@ class TestFiberSplit(unittest.TestCase):
         #
         self.assertEqual(len(split), len(css))
         for i, (sc, sp)  in enumerate(split):
-            self.assertEqual(sc, css[i][0])
+            self.assertEqual(sc, ranges[i][0])
+            self.assertEqual(sp, split_ref[i])
+            self.assertEqual(sp.getActive(), split_ref[i].getActive())
+
+    def test_split_unequal_pre_post_halo(self):
+        """Test splitUnequal with both pre_halo and post_halo"""
+
+        #
+        # Create the fiber to be split
+        #
+        c = [0, 1, 9, 10, 12, 31, 41, 51]
+        p = [1, 10, 20, 100, 120, 310, 410, 510 ]
+
+        f = Fiber(c,p, active_range=(0, 41))
+
+        #
+        # Create list of reference fibers after the split
+        #
+        css = [ [ 0, 1 ],
+                [ 0, 1, 9, 10 ],
+                [ 9, 10, 12, 31, 41 ] ]
+
+        pss = [ [ 1, 10 ],
+                [ 1, 10, 20, 100 ],
+                [ 20, 100, 120, 310, 410 ] ]
+
+        ranges = [(0, 1), (1, 10), (10, 41)]
+
+        split_ref = []
+
+        for cs, ps, range_ in zip(css, pss, ranges):
+            split_ref.append(Fiber(cs, ps, active_range=range_))
+
+        #
+        # Do the split
+        #
+        sizes = [1, 2, 3]
+        split = f.splitUnEqual(sizes, pre_halo=1, post_halo=1)
+
+        #
+        # Check the split
+        #
+        self.assertEqual(len(split), len(css))
+        for i, (sc, sp)  in enumerate(split):
+            self.assertEqual(sc, ranges[i][0])
             self.assertEqual(sp, split_ref[i])
             self.assertEqual(sp.getActive(), split_ref[i].getActive())
 

--- a/test/test_fiber_split.py
+++ b/test/test_fiber_split.py
@@ -1363,6 +1363,48 @@ class TestFiberSplit(unittest.TestCase):
 
         self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
 
+    def test_split_equal_pre_halo(self):
+        """splitEqual with pre_halo"""
+        # Original Fiber
+        c = [0, 1, 8, 9, 12, 15, 17, 19]
+        p = [1, 2, 3, 4,  5,  6,  7,  8]
+        f = Fiber(c, p)
+
+        #
+        # Create list of reference fibers after the split
+        #
+        split_ref_coords = [0, 9, 17]
+
+        css = [ [ 0, 1, 8 ],
+              [ 8, 9, 12, 15 ],
+              [ 15, 17, 19 ] ]
+
+        pss = [ [ 1, 2, 3 ],
+              [ 3, 4, 5, 6 ],
+              [ 6, 7, 8 ] ]
+
+        ranges = [(0, 9), (9, 17), (17, 20)]
+
+        split_ref_payloads = []
+
+        for cs, ps, range_ in zip(css, pss, ranges):
+            split_ref_payloads.append(Fiber(cs, ps, active_range=range_))
+
+        #
+        # Do the split
+        #
+        size = 3
+        split = f.splitEqual(size, pre_halo=2)
+
+        #
+        # Check the split
+        #
+        self.assertEqual(len(split), len(css))
+        for i, (sc, sp)  in enumerate(split):
+            self.assertEqual(sc, split_ref_coords[i])
+            self.assertEqual(sp, split_ref_payloads[i])
+            self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
+
     def test_split_equal_post_halo(self):
         """splitEqual with post_halo"""
         # Original Fiber
@@ -1395,6 +1437,88 @@ class TestFiberSplit(unittest.TestCase):
         #
         size = 3
         split = f.splitEqual(size, post_halo=3)
+
+        #
+        # Check the split
+        #
+        self.assertEqual(len(split), len(css))
+        for i, (sc, sp)  in enumerate(split):
+            self.assertEqual(sc, split_ref_coords[i])
+            self.assertEqual(sp, split_ref_payloads[i])
+            self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
+
+    def test_split_equal_pre_post_halo(self):
+        """splitEqual with pre_halo and post_halo"""
+        # Original Fiber
+        c = [0, 1, 8, 9, 12, 15, 17, 19]
+        p = [1, 2, 3, 4,  5,  6,  7,  8]
+        f = Fiber(c, p)
+
+        #
+        # Create list of reference fibers after the split
+        #
+        split_ref_coords = [0, 9, 17]
+
+        css = [ [ 0, 1, 8, 9 ],
+              [ 8, 9, 12, 15, 17, 19 ],
+              [ 15, 17, 19 ] ]
+
+        pss = [ [ 1, 2, 3, 4 ],
+              [ 3, 4, 5, 6, 7, 8 ],
+              [ 6, 7, 8 ] ]
+
+        ranges = [(0, 9), (9, 17), (17, 20)]
+
+        split_ref_payloads = []
+
+        for cs, ps, range_ in zip(css, pss, ranges):
+            split_ref_payloads.append(Fiber(cs, ps, active_range=range_))
+
+        #
+        # Do the split
+        #
+        size = 3
+        split = f.splitEqual(size, pre_halo=2, post_halo=3)
+
+        #
+        # Check the split
+        #
+        self.assertEqual(len(split), len(css))
+        for i, (sc, sp)  in enumerate(split):
+            self.assertEqual(sc, split_ref_coords[i])
+            self.assertEqual(sp, split_ref_payloads[i])
+            self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
+
+    def test_split_equal_pre_halo_active_only(self):
+        """splitEqual with pre_halo"""
+        # Original Fiber
+        c = [0, 8, 9, 11, 12, 15, 17, 18, 25]
+        p = [1, 2, 3, 4,  5,  6,  7,  8,  9 ]
+        f = Fiber(c, p, active_range=(9, 16))
+
+        #
+        # Create list of reference fibers after the split
+        #
+        split_ref_coords = [9, 15]
+
+        css = [ [ 8, 9, 11, 12],
+              [ 12, 15 ] ]
+
+        pss = [ [ 2, 3, 4, 5 ],
+              [ 5, 6 ] ]
+
+        ranges = [(9, 15), (15, 16)]
+
+        split_ref_payloads = []
+
+        for cs, ps, range_ in zip(css, pss, ranges):
+            split_ref_payloads.append(Fiber(cs, ps, active_range=range_))
+
+        #
+        # Do the split
+        #
+        size = 3
+        split = f.splitEqual(size, pre_halo=3)
 
         #
         # Check the split

--- a/test/test_fiber_split.py
+++ b/test/test_fiber_split.py
@@ -944,7 +944,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         self.assertEqual(len(split), len(css))
         for i, (sc, sp)  in enumerate(split):
-            self.assertEqual(sc, css[i][0])
+            self.assertEqual(sc, ranges[i][0])
             self.assertEqual(sp, split_ref[i])
             self.assertEqual(sp.getActive(), split_ref[i].getActive())
 
@@ -986,7 +986,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         self.assertEqual(len(split), len(css))
         for i, (sc, sp)  in enumerate(split):
-            self.assertEqual(sc, css[i][0])
+            self.assertEqual(sc, ranges[i][0])
             self.assertEqual(sp, split_ref[i])
             self.assertEqual(sp.getActive(), split_ref[i].getActive())
 
@@ -1326,7 +1326,7 @@ class TestFiberSplit(unittest.TestCase):
         #
         self.assertEqual(len(split), len(css))
         for i, (sc, sp)  in enumerate(split):
-            self.assertEqual(sc, css[i][0])
+            self.assertEqual(sc, ranges[i][0])
             self.assertEqual(sp, split_ref[i])
             self.assertEqual(sp.getActive(), split_ref[i].getActive())
 

--- a/test/test_fiber_split.py
+++ b/test/test_fiber_split.py
@@ -185,6 +185,51 @@ class TestFiberSplit(unittest.TestCase):
 
         self.assertEqual(split.getPayload(0).getDefault(), float("inf"))
 
+    def test_split_uniform_pre_halo(self):
+        """splitUniform with pre_halo"""
+        # Original Fiber
+        c = [8, 9, 12, 15, 17, 32, 38]
+        p = [3, 4,  5,  6,  7,  8,  9]
+        f = Fiber(c, p, active_range=(0, 43))
+
+        #
+        # Create list of reference fibers after the split
+        #
+        split_ref_coords = [8, 16, 32, 40]
+
+        css = [ [ 8, 9, 12, 15],
+              [ 15, 17 ],
+              [ 32, 38 ],
+              [ 38 ] ]
+
+        pss = [ [ 3, 4, 5, 6],
+              [ 6, 7 ],
+              [ 8, 9 ],
+              [ 9 ] ]
+
+
+        ranges = [(8, 16), (16, 24), (32, 40), (40, 43)]
+
+        split_ref_payloads = []
+
+        for cs, ps, range_ in zip(css, pss, ranges):
+            split_ref_payloads.append(Fiber(cs, ps, active_range=range_))
+
+        #
+        # Do the split
+        #
+        coords = 8
+        split = f.splitUniform(coords, pre_halo=2)
+
+        #
+        # Check the split
+        #
+        self.assertEqual(len(split), len(css))
+        for i, (sc, sp)  in enumerate(split):
+            self.assertEqual(sc, split_ref_coords[i])
+            self.assertEqual(sp, split_ref_payloads[i])
+            self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
+
 
     def test_split_uniform_post_halo(self):
         """splitUniform with post_halo"""
@@ -222,6 +267,100 @@ class TestFiberSplit(unittest.TestCase):
         #
         coords = 8
         split = f.splitUniform(coords, post_halo=2)
+
+        #
+        # Check the split
+        #
+        self.assertEqual(len(split), len(css))
+        for i, (sc, sp)  in enumerate(split):
+            self.assertEqual(sc, split_ref_coords[i])
+            self.assertEqual(sp, split_ref_payloads[i])
+            self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
+
+    def test_split_uniform_pre_post_halo(self):
+        """splitUniform with pre_halo and post_halo"""
+        # Original Fiber
+        c = [8, 9, 12, 15, 17, 32, 38]
+        p = [3, 4,  5,  6,  7,  8,  9]
+        f = Fiber(c, p, active_range=(0, 43))
+
+        #
+        # Create list of reference fibers after the split
+        #
+        split_ref_coords = [0, 8, 16, 24, 32, 40]
+
+        css = [ [ 8 ],
+              [ 8, 9, 12, 15],
+              [ 15, 17 ],
+              [ 32 ],
+              [ 32, 38 ],
+              [ 38 ] ]
+
+        pss = [ [ 3 ],
+              [ 3, 4, 5, 6],
+              [ 6, 7 ],
+              [ 8 ],
+              [ 8, 9 ],
+              [ 9 ] ]
+
+
+        ranges = [(0, 8), (8, 16), (16, 24), (24, 32), (32, 40), (40, 43)]
+
+        split_ref_payloads = []
+
+        for cs, ps, range_ in zip(css, pss, ranges):
+            split_ref_payloads.append(Fiber(cs, ps, active_range=range_))
+
+        #
+        # Do the split
+        #
+        coords = 8
+        split = f.splitUniform(coords, pre_halo=2, post_halo=1)
+
+        #
+        # Check the split
+        #
+        self.assertEqual(len(split), len(css))
+        for i, (sc, sp)  in enumerate(split):
+            self.assertEqual(sc, split_ref_coords[i])
+            self.assertEqual(sp, split_ref_payloads[i])
+            self.assertEqual(sp.getActive(), split_ref_payloads[i].getActive())
+
+    def test_split_uniform_pre_halo_active_only(self):
+        """splitUniform with pre_halo active only"""
+        # Original Fiber
+        c = [8, 9, 12, 15, 17, 32, 38]
+        p = [3, 4,  5,  6,  7,  8,  9]
+        f = Fiber(c, p, active_range=(13, 43))
+
+        #
+        # Create list of reference fibers after the split
+        #
+        split_ref_coords = [8, 16, 32, 40]
+
+        css = [ [ 12, 15],
+              [ 15, 17 ],
+              [ 32, 38 ],
+              [ 38 ] ]
+
+        pss = [ [ 5, 6],
+              [ 6, 7 ],
+              [ 8, 9 ],
+              [ 9 ] ]
+
+
+        ranges = [(13, 16), (16, 24), (32, 40), (40, 43)]
+
+        split_ref_payloads = []
+
+        for cs, ps, range_ in zip(css, pss, ranges):
+            split_ref_payloads.append(Fiber(cs, ps, active_range=range_))
+
+        #
+        # Do the split
+        #
+        coords = 8
+        split = f.splitUniform(coords, pre_halo=2)
 
         #
         # Check the split

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -56,7 +56,7 @@ class TestTensorTransform(unittest.TestCase):
         I_W_cropped = Tensor.fromFiber(rank_ids=["W"], fiber=I_W.getRoot(), shape=[Q])
         self.assertEqual(I_W_cropped.getRoot().getActive(), (0, 36))
 
-        I_Q1W0 = I_W_cropped.getRoot().splitUniform(Q0, halo=S - 1)
+        I_Q1W0 = I_W_cropped.getRoot().splitUniform(Q0, post_halo=S - 1)
         self.assertEqual(I_Q1W0.getActive(), (0, 36))
 
 


### PR DESCRIPTION
Rename the `halo` parameter of the `split...()` methods to `post_halo`, since it denoted a halo after the active range of the partition, and add a `pre_halo` parameter.