### PR TITLE
Support float coords

### DIFF
--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -2556,7 +2556,8 @@ class Fiber:
             The coordinate with the function applied to all integers
 
         """
-        assert isinstance(coord, tuple) or isinstance(coord, int) or isinstance(coord, Any)
+        assert isinstance(coord, tuple) or isinstance(coord, int) \
+            or isinstance(coord, float) or isinstance(coord, Any)
 
         if isinstance(coord, tuple):
             return tuple(Fiber._transCoord(c, trans_fn) for c in coord)

--- a/test/test_fiber.py
+++ b/test/test_fiber.py
@@ -3399,5 +3399,16 @@ class TestFiber(unittest.TestCase):
 
         self.assertEqual(mf.getDefault(), float("inf"))
 
+    def test_trans_coord(self):
+        """Test that Fiber._transCoord works on all desired datatypes"""
+        self.assertEqual(Fiber._transCoord((1, 2), lambda c: c + 1), (2, 3))
+        self.assertEqual(Fiber._transCoord(2, lambda c: c + 1), 3)
+        self.assertEqual(Fiber._transCoord(2.1, lambda c: c + 1), 3.1)
+        self.assertEqual(Fiber._transCoord(Any(), lambda c: c + 1), Any())
+
+        with self.assertRaises(AssertionError):
+            Fiber._transCoord("foo", lambda c: c + "bar")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allow `Fiber._transCoord`, which is used in a number of fiber operations, including `mergeRanks`, `project`, and `getActive` to act on `float` coordinates. Add a test for this method.