### PR TITLE
Correctly flatten str and list rank ids together

### DIFF
--- a/fibertree/core/tensor.py
+++ b/fibertree/core/tensor.py
@@ -1632,7 +1632,7 @@ class Tensor:
             next_rankid = rank_ids[depth + 1]
 
             if isinstance(next_rankid, list):
-                rank_ids[depth] = cur_rankid + next_rankid
+                rank_ids[depth] += next_rankid
             else:
                 rank_ids[depth].append(next_rankid)
 

--- a/test/test_tensor_transform.py
+++ b/test/test_tensor_transform.py
@@ -546,6 +546,24 @@ class TestTensorTransform(unittest.TestCase):
         self.assertEqual(f4, t0)
         self.assertEqual(f4.getDefault(), float("inf"))
 
+    def test_flattenRanks_shape_correct(self):
+        """Test flattenRanks - levels=3, coord_style=absolute"""
+        t0 = Tensor.fromUncompressed(rank_ids=["A"], root=list(range(16)))
+        t0.setDefault(float("inf"))
+        self.assertEqual(t0.getDefault(), float("inf"))
+
+        s1 = t0.splitUniform(8, depth=0)
+        s2 = s1.splitUniform(4, depth=1)
+        s2.setRankIds(["A2", "A1", "A0"])
+
+        f4 = s2.flattenRanks(depth=1, levels=1, coord_style="absolute")
+        f4 = f4.flattenRanks(depth=0, levels=1, coord_style="absolute")
+        f4.setRankIds(["A"])
+
+        self.assertEqual(f4, t0)
+        self.assertEqual(f4.getDefault(), float("inf"))
+
+
     def test_merge(self):
         """Test that mergeRanks merges together fibers"""
         f = Fiber([0, 1, 4, 5],


### PR DESCRIPTION
Correctly flatten together the rank ID names when the current rank name is a string and the rank to be flattened into it has a list name.