### PR TITLE
Actually Include Fiber.fromCoordPayloadList Fix

### DIFF
--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -297,7 +297,7 @@ class Fiber:
         self.iter = None
 
     @classmethod
-    def fromCoordPayloadList(cls, *cp, **kwargs):
+    def fromCoordPayloadList(cls, cp, **kwargs):
         """Construct a Fiber from a coordinate/payload list.
 
         The base Fiber contructor creates a fiber from a list of a


### PR DESCRIPTION
`Fiber.fromCoordPayloadList` should take a list of tuples (according to the documentation), but instead it took many tuple arguments. Updated the code and tests so that the implementation was in line with this.