### PR TITLE
Align implementation with current documentation/expected behavior

### DIFF
--- a/fibertree/core/fiber.py
+++ b/fibertree/core/fiber.py
@@ -297,7 +297,7 @@ class Fiber:
         self.iter = None
 
     @classmethod
-    def fromCoordPayloadList(cls, *cp, **kwargs):
+    def fromCoordPayloadList(cls, cp, **kwargs):
         """Construct a Fiber from a coordinate/payload list.
 
         The base Fiber contructor creates a fiber from a list of a

--- a/test/test_fiber.py
+++ b/test/test_fiber.py
@@ -108,20 +108,15 @@ class TestFiber(unittest.TestCase):
         (coords, payloads) = zip(*cp)
 
         a_ref = Fiber(coords=coords, payloads=payloads)
+        print(repr(a_ref))
 
-        a1 = Fiber.fromCoordPayloadList(*cp)
+        a1 = Fiber.fromCoordPayloadList(cp)
         self.assertEqual(a1, a_ref)
         self.assertEqual(a1.getDefault(), 0)
 
-        # Removed functionality to set fiber default
-
-#       a2 = Fiber.fromCoordPayloadList(*cp, default=1)
-#       self.assertEqual(a2, a_ref)
-#       self.assertEqual(a2.getDefault(), 1)
-
-#       a3 = Fiber.fromCoordPayloadList(default=2, *cp)
-#       self.assertEqual(a3, a_ref)
-#       self.assertEqual(a3.getDefault(), 2)
+        a2 = Fiber.fromCoordPayloadList(cp, default=1)
+        self.assertEqual(a2, a_ref)
+        self.assertEqual(a2.getDefault(), 1)
 
 
     def test_fromYAMLfile_1D(self):

--- a/test/test_fiber.py
+++ b/test/test_fiber.py
@@ -108,7 +108,6 @@ class TestFiber(unittest.TestCase):
         (coords, payloads) = zip(*cp)
 
         a_ref = Fiber(coords=coords, payloads=payloads)
-        print(repr(a_ref))
 
         a1 = Fiber.fromCoordPayloadList(cp)
         self.assertEqual(a1, a_ref)


### PR DESCRIPTION
`Fiber.fromCoordPayloadList` should take a list of tuples (according to the documentation), but instead it took many tuple arguments. Updated the code and tests so that the implementation was in line with this.